### PR TITLE
feat: Make express types less strict

### DIFF
--- a/.changeset/sweet-trains-cover.md
+++ b/.changeset/sweet-trains-cover.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/express': minor
+---
+
+Make createExpressEndpoints take IRouter instead of Express

--- a/libs/ts-rest/express/src/lib/ts-rest-express.ts
+++ b/libs/ts-rest/express/src/lib/ts-rest-express.ts
@@ -1,4 +1,4 @@
-import { Express, RequestHandler } from 'express';
+import { IRouter, RequestHandler } from 'express';
 import { z, ZodTypeAny } from 'zod';
 import {
   AppRoute,
@@ -86,7 +86,7 @@ const transformAppRouteQueryImplementation = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   route: AppRouteQueryImplementation<any>,
   schema: AppRouteQuery,
-  app: Express
+  app: IRouter
 ) => {
   console.log(`[ts-rest] Initialized ${schema.method} ${schema.path}`);
 
@@ -113,7 +113,7 @@ const transformAppRouteMutationImplementation = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   route: AppRouteMutationImplementation<any>,
   schema: AppRouteMutation,
-  app: Express
+  app: IRouter
 ) => {
   console.log(`[ts-rest] Initialized ${schema.method} ${schema.path}`);
 
@@ -179,7 +179,7 @@ export const createExpressEndpoints = <
 >(
   schema: TRouter,
   router: T,
-  app: Express
+  app: IRouter
 ) => {
   recursivelyApplyExpressRouter(router, [], (route, path) => {
     const routerViaPath = getValue(schema, path.join('.'));


### PR DESCRIPTION
Allow using both `express()` and `Router()` objects for `createExpressEndpoints`