### PR TITLE
feat: Expose request headers in express router

### DIFF
--- a/.changeset/pretty-kings-burn.md
+++ b/.changeset/pretty-kings-burn.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/express': patch
+---
+
+Expose request headers in express router

--- a/libs/ts-rest/express/src/lib/ts-rest-express.ts
+++ b/libs/ts-rest/express/src/lib/ts-rest-express.ts
@@ -1,5 +1,6 @@
 import { Express, RequestHandler } from 'express';
 import { z, ZodTypeAny } from 'zod';
+import { IncomingHttpHeaders } from 'http';
 import {
   AppRoute,
   AppRouteMutation,
@@ -25,6 +26,7 @@ type AppRouteQueryImplementation<T extends AppRouteQuery> = (
     {
       params: PathParams<T>;
       query: T['query'] extends ZodTypeAny ? z.infer<T['query']> : null;
+      headers: IncomingHttpHeaders;
     },
     never
   >
@@ -36,6 +38,7 @@ type AppRouteMutationImplementation<T extends AppRouteMutation> = (
       params: PathParams<T>;
       query: T['query'] extends ZodTypeAny ? z.infer<T['query']> : never;
       body: T['body'] extends ZodTypeAny ? z.infer<T['body']> : never;
+      headers: IncomingHttpHeaders;
     },
     never
   >
@@ -103,6 +106,7 @@ const transformAppRouteQueryImplementation = (
       // @ts-expect-error because the decorator shape is any
       params: req.params,
       query: req.query,
+      headers: req.headers,
     });
 
     return res.status(Number(result.status)).json(result.body);
@@ -145,6 +149,7 @@ const transformAppRouteMutationImplementation = (
         params: req.params,
         body: req.body,
         query: req.query,
+        headers: req.headers,
       });
 
       return res.status(Number(result.status)).json(result.body);


### PR DESCRIPTION
I would like to be able to access the request headers from my express handler in order to do custom authentication logic of the request.