### PR TITLE
feat: Set operationId in open-api docs

### DIFF
--- a/.changeset/red-seals-fry.md
+++ b/.changeset/red-seals-fry.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/open-api': minor
+---
+
+Allow setting operationId in open-api docs

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
@@ -1,0 +1,136 @@
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+import { OpenAPIObject } from 'openapi3-ts';
+import { generateOpenApi } from './ts-rest-open-api';
+
+const c = initContract();
+
+type Post = {
+  title: string;
+  published: boolean;
+};
+
+const postsRouter = c.router({
+  getPost: {
+    method: 'GET',
+    path: `/posts/:id`,
+    responses: {
+      200: c.response<Post | null>(),
+    },
+  },
+  createPost: {
+    method: 'POST',
+    path: '/posts',
+    deprecated: true,
+    responses: {
+      200: c.response<Post>(),
+    },
+    body: z.object({
+      title: z.string(),
+      published: z.boolean().optional(),
+    }),
+  },
+});
+
+const router = c.router({
+  posts: postsRouter,
+  health: {
+    method: 'GET',
+    path: '/health',
+    summary: 'Health API',
+    description: `Check the application's health status`,
+    responses: {
+      200: c.response<{ message: string }>(),
+    },
+  },
+});
+
+const expectedApiDoc = {
+  info: {
+    title: 'Blog API',
+    version: '0.1',
+  },
+  openapi: '3.0.0',
+  paths: {
+    '/health': {
+      get: {
+        deprecated: undefined,
+        description: "Check the application's health status",
+        parameters: undefined,
+        responses: {
+          '200': {
+            description: '200',
+          },
+        },
+        summary: 'Health API',
+        tags: [],
+      },
+    },
+    '/posts': {
+      post: {
+        deprecated: true,
+        description: undefined,
+        parameters: undefined,
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                additionalProperties: false,
+                properties: {
+                  published: {
+                    type: 'boolean',
+                  },
+                  title: {
+                    type: 'string',
+                  },
+                },
+                required: ['title'],
+                type: 'object',
+              },
+            },
+          },
+          description: 'Body',
+        },
+        responses: {
+          '200': {
+            description: '200',
+          },
+        },
+        summary: undefined,
+        tags: ['posts'],
+      },
+    },
+    '/posts/{id}': {
+      get: {
+        deprecated: undefined,
+        description: undefined,
+        parameters: [
+          {
+            in: 'path',
+            name: 'id',
+            required: true,
+          },
+        ],
+        responses: {
+          '200': {
+            description: '200',
+          },
+        },
+        summary: undefined,
+        tags: ['posts'],
+      },
+    },
+  },
+};
+
+describe('ts-rest-open-api', () => {
+  describe('generateOpenApi', () => {
+    it('w/ no parameters', async () => {
+      const apiDoc = generateOpenApi(router, {
+        info: { title: 'Blog API', version: '0.1' },
+      });
+
+      expect(apiDoc).toEqual(expectedApiDoc);
+    });
+  });
+});


### PR DESCRIPTION
From what I understand the route keys in the contract should be unique within the router so they are suitable candidates for using as the operationId when generate openapi docs.

The only thing I'm not 100% sure about is when using nested routers, I guess there is no easy way to ensure strict uniques throughout the whole contract in that case?