### PR TITLE
Change `initContract` import in quickstart section

### DIFF
--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -25,7 +25,7 @@ yarn add @ts-rest/core
 ```typescript
 // contract.ts
 
-import { initTsRest } from '@ts-rest/core';
+import { initContract } from '@ts-rest/core';
 
 const c = initContract();
 


### PR DESCRIPTION
According to `initTsRest` is deprecated this PR update quickstart section to use `initContract` insead.