### PR TITLE
feat: add credentials option for fetch client

### DIFF
--- a/.changeset/witty-apricots-exercise.md
+++ b/.changeset/witty-apricots-exercise.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': minor
+---
+
+Add credentials option for fetch client

--- a/apps/docs/docs/core/custom.md
+++ b/apps/docs/docs/core/custom.md
@@ -1,5 +1,10 @@
 # Custom Client
 
+:::info
+The `credentials` option has no effect when using a custom client. Make sure you handle credentials in your custom client
+(e.g., setting `withCredentials` in axios).
+:::
+
 ## Using Axios (custom api override)
 
 By default ts-rest ships with an incredibly simple fetch 

--- a/apps/docs/docs/core/fetch.md
+++ b/apps/docs/docs/core/fetch.md
@@ -55,3 +55,17 @@ const data: {
 }
 ```
 :::
+
+
+## Credentials (sending cookies)
+
+The `fetch()` function used by ts-rest does not send cookies in cross-origin requests by default unless the `credentials`
+option is set to `include`.
+
+```typescript
+const client = initClient(contract, {
+  baseUrl: "http://localhost:3333/api",
+  baseHeaders: {},
+  credentials: 'include'
+})
+```

--- a/apps/docs/sidebars.js
+++ b/apps/docs/sidebars.js
@@ -39,6 +39,7 @@ const sidebars = {
       items: [
         { type: 'doc', id: 'core/core' },
         { type: 'doc', id: 'core/fetch' },
+        { type: 'doc', id: 'core/custom' },
         { type: 'doc', id: 'core/errors' },
         { type: 'doc', id: 'core/form-data' },
       ],

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -74,6 +74,7 @@ export interface ClientArgs {
   baseUrl: string;
   baseHeaders: Record<string, string>;
   api?: ApiFetcher;
+  credentials?: RequestCredentials;
 }
 
 type ApiFetcher = (args: {
@@ -81,6 +82,7 @@ type ApiFetcher = (args: {
   method: string;
   headers: Record<string, string>;
   body: FormData | string | null | undefined;
+  credentials?: RequestCredentials;
 }) => Promise<{ status: number; body: unknown }>;
 
 export const defaultApi: ApiFetcher = async ({
@@ -88,8 +90,9 @@ export const defaultApi: ApiFetcher = async ({
   method,
   headers,
   body,
+  credentials,
 }) => {
-  const result = await fetch(path, { method, headers, body });
+  const result = await fetch(path, { method, headers, body, credentials });
 
   try {
     return {
@@ -130,6 +133,7 @@ export const fetchApi = (
     return apiFetcher({
       path,
       method: route.method,
+      credentials: clientArgs.credentials,
       headers: {
         ...clientArgs.baseHeaders,
       },
@@ -140,6 +144,7 @@ export const fetchApi = (
   return apiFetcher({
     path,
     method: route.method,
+    credentials: clientArgs.credentials,
     headers: {
       ...clientArgs.baseHeaders,
       'Content-Type': 'application/json',


### PR DESCRIPTION
For APIs authenticated using cookies, the cookies are not being sent by default for cross-origin requests, as the default behavior for the fetch API is to use a `same-origin` policy. This means if the API is even on a different subdomain (api.example.com) or a different port, say when running locally, no cookies will be sent. This happens regardless of any CORS headers sent by the backend API.

The only way to solve this problem is to use a custom client using the `api` option, so I've added a `credentials` option that will set the same option on the Fetch API to avoid overriding the client.

I've documented this feature in the docs and added the missing sidebar link to the "custom client" page.