### PR TITLE
fix: add missing query parameters in OpenAPI

### DIFF
--- a/.changeset/swift-zebras-jam.md
+++ b/.changeset/swift-zebras-jam.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/open-api': patch
+---
+
+Fixed missing query parameters in generated OpenAPI


### PR DESCRIPTION
Hi again!

Query parameters were missing in generated OpenAPI specs so I've added them. I've also expanded on the unit tests to make sure it tests nested routers and setting tags correctly (i.e., `/posts/:id/comments` should set `tags: ['posts', 'comments']`)

There are different ways to serialize query parameters and OpenAPI can be instructed on how to handle these as outlined [here](https://swagger.io/docs/specification/serialization/#:~:text=values%20get%20prefixed.-,Query%20Parameters,-Query%20parameters%20support), but by default, express.js and the like use the default OpenAPI `style` and `explode` formats to handle arrays and objects so I see no compelling reason to add `style` and `explode` options to `generateOpenApi`.

In the case of nested objects, this is not defined in OpenAPI 3.0, however they are supported by express.js, so this is an edge-case that could not be handled at the moment.

Also that the `nest` library is handling query parsing itself using `URLSearchParams` which only handles basic string query params but no arrays or nested objects, unlike the `express` and `next` libs which will take whatever is in `req.query` set by the framework. I have another PR incoming to fix that issue.