### PR TITLE
fix: use z.input for body and query types on clients

### DIFF
--- a/.changeset/eleven-roses-know.md
+++ b/.changeset/eleven-roses-know.md
@@ -1,0 +1,7 @@
+---
+'@ts-rest/core': patch
+'@ts-rest/react-query': patch
+'@ts-rest/solid-query': patch
+---
+
+Use z.input for body and query types for clients

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -16,7 +16,7 @@ type RecursiveProxyObj<T extends AppRouter> = {
     : never;
 };
 
-type AppRouteMutationType<T> = T extends ZodTypeAny ? z.infer<T> : T;
+type AppRouteMutationType<T> = T extends ZodTypeAny ? z.input<T> : T;
 
 /**
  * Extract the path params from the path in the contract

--- a/libs/ts-rest/react-query/src/lib/ts-rest-client.ts
+++ b/libs/ts-rest/react-query/src/lib/ts-rest-client.ts
@@ -39,7 +39,7 @@ type RecursiveProxyObj<T extends AppRouter> = {
     : never;
 };
 
-type AppRouteMutationType<T> = T extends ZodTypeAny ? z.infer<T> : T;
+type AppRouteMutationType<T> = T extends ZodTypeAny ? z.input<T> : T;
 
 type UseQueryArgs<TAppRoute extends AppRoute> = {
   useQuery: TAppRoute extends AppRouteQuery

--- a/libs/ts-rest/solid-query/src/lib/solid-query.ts
+++ b/libs/ts-rest/solid-query/src/lib/solid-query.ts
@@ -39,7 +39,7 @@ type RecursiveProxyObj<T extends AppRouter> = {
     : never;
 };
 
-type AppRouteMutationType<T> = T extends ZodTypeAny ? z.infer<T> : T;
+type AppRouteMutationType<T> = T extends ZodTypeAny ? z.input<T> : T;
 
 type UseQueryArgs<TAppRoute extends AppRoute> = {
   createQuery: TAppRoute extends AppRouteQuery


### PR DESCRIPTION
For cases where zod input and output types differ such as when using `.default()` or `.transform()`, we need to use the input type on the client-side.

```typescript
const foo = z.object({ bar: z.string().default('bar') });
type input = z.input<typeof foo>; // { bar?: string | undefined }
type output = z.infer<typeof foo>; // { bar: string }
```