### PR TITLE
fix: let nx generate correct package.json

### DIFF
--- a/.changeset/wise-owls-hunt.md
+++ b/.changeset/wise-owls-hunt.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/react-query': patch
+---
+
+Fix missing typings due to new declaration file path

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Create a contract, implement it on your server then consume it in your client. I
 
 ## Stargazers over Time ⭐️
 
-[![Stargazers over time](https://starchart.cc/ts-rest/ts-rest.svg)](https://starchart.cc/pragmaticivan/nestjs-otel)
+[![Stargazers over time](https://starchart.cc/ts-rest/ts-rest.svg)](https://starchart.cc/ts-rest/ts-rest)
 
 ## Contributors ✨
 

--- a/libs/ts-rest/react-query/package.json
+++ b/libs/ts-rest/react-query/package.json
@@ -32,16 +32,5 @@
     "react": "16.x.x || 17.x.x || 18.x.x",
     "zod": "3.x.x",
     "@tanstack/react-query": "4.x.x"
-  },
-  "exports": {
-    ".": {
-      "import": "./index.js",
-      "require": "./index.cjs"
-    },
-    "./package.json": "./package.json"
-  },
-  "main": "index.cjs",
-  "module": "index.js",
-  "types": "index.d.ts",
-  "typings": "index.d.ts"
+  }
 }


### PR DESCRIPTION
NX strikes again 😅
Looks like with the update to version 15.3, it started generating the libraries with a different file structure, and it's causing this error `TS7016: Could not find a declaration file for module '@ts-rest/react-query'.`

![Screenshot 2022-12-11 000846](https://user-images.githubusercontent.com/1728215/206877224-8d411e1a-1b30-4884-b7d4-883fe822ff52.jpg)

NX automatically generates this if it is not declared explicitly

```json
{
  "module": "./index.js",
  "main": "./index.cjs",
  "type": "module",
  "types": "./src/index.d.ts"
}
```

@ts-rest/react-query is the only package with these paths explicitly declared and became invalid when nx started generating index.d.ts inside ./src/index.d.ts instead of ./index.d.ts