### PR TITLE
fix: revert react-query exports in package.json

### DIFF
--- a/.changeset/flat-rings-sell.md
+++ b/.changeset/flat-rings-sell.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/react-query': patch
+---
+
+Revert @ts-rest/react-query exports in package.json

--- a/libs/ts-rest/react-query/package.json
+++ b/libs/ts-rest/react-query/package.json
@@ -32,5 +32,12 @@
     "react": "16.x.x || 17.x.x || 18.x.x",
     "zod": "3.x.x",
     "@tanstack/react-query": "4.x.x"
+  },
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "require": "./index.cjs"
+    },
+    "./package.json": "./package.json"
   }
 }


### PR DESCRIPTION
@oliverbutler Sorry about this, I removed the exports from the package.json in the last PR and it seems like it broke something and I have no idea why, but you probably had it in there for the some valid reason. Without the exports in package.json I get this error in Next.js

`No QueryClient set, use QueryClientProvider to set one`

From some quick research it seems like this happens when different react-query versions are being used, but I could not observe that in my case so I dunno honestly 🤷‍♂️