### PR TITLE
fix: don't use $ref in OpenAPI

### DIFF
--- a/.changeset/long-snails-hammer.md
+++ b/.changeset/long-snails-hammer.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/open-api': patch
+---
+
+Don't use $ref in OpenAPI

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
@@ -9,6 +9,11 @@ type Post = {
   published: boolean;
 };
 
+const commentSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+});
+
 const postsRouter = c.router({
   getPost: {
     method: 'GET',
@@ -47,7 +52,10 @@ const postsRouter = c.router({
       path: '/posts/:id/comments',
       responses: {
         200: z.object({
-          comments: z.array(z.string()),
+          comments: z.union([
+            z.array(commentSchema),
+            z.array(commentSchema.extend({ author: z.string() })),
+          ]),
         }),
       },
     },
@@ -197,10 +205,43 @@ const expectedApiDoc = {
                   additionalProperties: false,
                   properties: {
                     comments: {
-                      items: {
-                        type: 'string',
-                      },
-                      type: 'array',
+                      anyOf: [
+                        {
+                          items: {
+                            additionalProperties: false,
+                            properties: {
+                              id: {
+                                type: 'number',
+                              },
+                              title: {
+                                type: 'string',
+                              },
+                            },
+                            required: ['id', 'title'],
+                            type: 'object',
+                          },
+                          type: 'array',
+                        },
+                        {
+                          items: {
+                            additionalProperties: false,
+                            properties: {
+                              author: {
+                                type: 'string',
+                              },
+                              id: {
+                                type: 'number',
+                              },
+                              title: {
+                                type: 'string',
+                              },
+                            },
+                            required: ['id', 'title', 'author'],
+                            type: 'object',
+                          },
+                          type: 'array',
+                        },
+                      ],
                     },
                   },
                   required: ['comments'],

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
@@ -49,6 +49,7 @@ const getJsonSchemaFromZod = (zodObject: unknown) => {
   const schema = zodToJsonSchema(zodObject, {
     name: 'zodObject',
     target: 'openApi3',
+    $refStrategy: 'none',
   });
 
   return schema.definitions['zodObject'];


### PR DESCRIPTION
If the same zod object is used multiple times in the same contract object (query, body or response), it will use a $ref to refer to it's first occurrence. For the example in test code, it would have generated to following JSON schema.

```json
"comments": {
  "anyOf": [
	{
	  "items": {
		"additionalProperties": false,
		"properties": {
		  "id": {
			"type": "number"
		  },
		  "title": {
			"type": "string"
		  }
		},
		"required": [
		  "id",
		  "title"
		],
		"type": "object"
	  },
	  "type": "array"
	},
	{
	  "items": {
		"additionalProperties": false,
		"properties": {
		  "author": {
			"type": "string"
		  },
		  "id": {
			"$ref": "#/definitions/zodObject/properties/comments/anyOf/0/items/properties/id"
		  },
		  "title": {
			"$ref": "#/definitions/zodObject/properties/comments/anyOf/0/items/properties/title"
		  }
		},
		"required": [
		  "id",
		  "title",
		  "author"
		],
		"type": "object"
	  },
	  "type": "array"
	}
  ]
}
```

Since we aren't actually bundling any definitions, these references don't resolve and we end up with an error like this.

![Screenshot 2022-12-16 210549](https://user-images.githubusercontent.com/1728215/208175077-5ecd83ab-68a7-4673-9b55-71926dcfa7b5.jpg)

We also fix this by naming and bundling all definitions generated, but it'll be so clunky. We'd end up with definitions named something like commentsGetPostCommentsResponses200