### PR TITLE
feat: add response shape feature, update docs

### DIFF
--- a/.changeset/hot-wasps-cry.md
+++ b/.changeset/hot-wasps-cry.md
@@ -1,0 +1,6 @@
+---
+'@ts-rest/core': minor
+'@ts-rest/nest': minor
+---
+
+Add response shape shape helper to make allow you to extract the response from a Contract route

--- a/apps/docs/docs/core/core.md
+++ b/apps/docs/docs/core/core.md
@@ -95,3 +95,26 @@ export const contract = c.router({
   },
 });
 ```
+
+## Response Types
+
+If you need to quickly extract the Response types from a given Contract, you can use `getRouteResponses`.
+
+:warning: This does not support nested contracts yet. You need to pass in a defined contract. 
+
+`getRouteResponses(router)` returns an empty object with defined response types for a contract's HTTP method. 
+
+```typescript
+import { getRouteResponses } from '@ts-rest/core'
+import { contract } from './contract'
+
+//  initContract() must called prior
+const contractResponses = getRouteResponses(contract)
+type ResponseShapes = typeof contractResponses
+
+async function someHttpCall(req: Request): Promise<ResponseShapes['getPosts']> {
+  return ...
+}
+```
+
+This is particularly useful for Services/Functions/Lambdas that do not use frameworks like Express or Nestjs. 

--- a/apps/docs/docs/nest.md
+++ b/apps/docs/docs/nest.md
@@ -55,10 +55,10 @@ You have two options to ensure HTTP type safety on your Nest Controllers:
         const post = await this.postService.getPost(id);
 
         if (!post) {
-          return { status: 404 as const, body: null };
+          return { status: 404, body: null };
         }
 
-        return { status: 200 as const, body: post };
+        return { status: 200, body: post };
       }
     }
     ```

--- a/apps/docs/docs/nest.md
+++ b/apps/docs/docs/nest.md
@@ -62,7 +62,7 @@ You have two options to ensure HTTP type safety on your Nest Controllers:
       }
     }
     ```
-  - If your controller needs to implement a difference class, or needs extra methods defined outside of a contract, this is option gives that flexibility
+  - If your controller needs to implement a difference class, or needs extra methods defined outside of a contract, this is option gives that flexibility without having to worry about maintaining class extensions. 
 
 
 :::caution

--- a/apps/docs/docs/nest.md
+++ b/apps/docs/docs/nest.md
@@ -6,6 +6,7 @@ By default Nest doesn't offer a nice way to ensure type safe controllers, primar
 const s = initNestServer(apiBlog);
 type ControllerShape = typeof s.controllerShape;
 type RouteShape = typeof s.routeShapes;
+type ResponseShapes = typeof s.responseShapes;
 
 @Controller()
 export class PostController implements ControllerShape {
@@ -27,6 +28,42 @@ export class PostController implements ControllerShape {
 The `@Api` decorator takes the route, defines the path and method for the controller route.
 
 It also injects "appRoute" into the req object, allowing the `@ApiDecorator` decorator automatically parse and check the query and body parameters.
+
+
+## Response Return Type Safety
+
+You have two options to ensure HTTP type safety on your Nest Controllers: 
+
+- `ControllerShape` as shown above: 
+  - Your controller can implement the `ControllerShape` derived from `typeof s.controllerShape`
+  - This ensures your controller methods also align with the base interface shapes
+- `ResponseShapes`:
+  - Your controller can utilize `typeof s.responseShapes` in the return type. For example:
+    ```typescript
+    const s = initNestServer(apiBlog);
+    type ControllerShape = typeof s.controllerShape;
+    type RouteShape = typeof s.routeShapes;
+    type ResponseShapes = typeof s.responseShapes; // <- http Responses defined in contract
+
+    @Controller()
+    export class PostController {
+      constructor(private readonly postService: PostService) {}
+
+      @Api(s.route.getPost)
+      async getPost(@ApiDecorator() { params: { id } }: RouteShape['getPost']):
+      Promise<ResponseShapes['getPost']> { // <- return type defined here
+        const post = await this.postService.getPost(id);
+
+        if (!post) {
+          return { status: 404 as const, body: null };
+        }
+
+        return { status: 200 as const, body: post };
+      }
+    }
+    ```
+  - If your controller needs to implement a difference class, or needs extra methods defined outside of a contract, this is option gives that flexibility
+
 
 :::caution
 

--- a/apps/example-nest/src/app/post.controller.withResponseShapes.spec.ts
+++ b/apps/example-nest/src/app/post.controller.withResponseShapes.spec.ts
@@ -1,0 +1,120 @@
+import { PostService } from './post.service';
+import { Test } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { PostController } from './post.controller';
+
+describe('PostController', () => {
+  let app: INestApplication;
+  let postService: PostService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [PostController],
+      providers: [
+        {
+          provide: PostService,
+          useValue: {
+            getPosts: jest.fn(),
+            createPost: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    postService = moduleRef.get<PostService>(PostService);
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  describe('GET /posts', () => {
+    it('should transform skip and take into numbers', async () => {
+      jest.spyOn(postService, 'getPosts').mockResolvedValue([] as any);
+
+      return request(app.getHttpServer())
+        .get('/posts')
+        .query('skip=0&take=10')
+        .expect(200)
+        .expect({
+          skip: 0,
+          take: 10,
+        });
+    });
+
+    it('should error if a required query param is missing', async () => {
+      return request(app.getHttpServer())
+        .get('/posts')
+        .query('skip=0')
+        .expect(400)
+        .expect({
+          issues: [
+            {
+              code: 'invalid_type',
+              expected: 'string',
+              message: 'Required',
+              path: ['take'],
+              received: 'undefined',
+            },
+          ],
+          name: 'ZodError',
+        });
+    });
+  });
+
+  describe('POST /posts', () => {
+    it('should error if body is incorrect', async () => {
+      return request(app.getHttpServer())
+        .post('/posts')
+        .send({
+          title: 'Good title',
+          content: 123,
+        })
+        .expect(400)
+        .expect({
+          issues: [
+            {
+              code: 'invalid_type',
+              expected: 'string',
+              message: 'Expected string, received number',
+              path: ['content'],
+              received: 'number',
+            },
+          ],
+          name: 'ZodError',
+        });
+    });
+
+    it('should transform body correctly', async () => {
+      jest
+        .spyOn(postService, 'createPost')
+        .mockImplementationOnce(async (post) => post as any);
+
+      return request(app.getHttpServer())
+        .post('/posts')
+        .send({
+          title: 'Title with extra spaces     ',
+          content: 'content',
+        })
+        .expect(201)
+        .expect({
+          title: 'Title with extra spaces',
+          content: 'content',
+        });
+    });
+  });
+
+  it('should format params using pathParams correctly', async () => {
+    return request(app.getHttpServer())
+      .get('/test/123/name')
+      .expect(200)
+      .expect({
+        id: 123,
+        name: 'name',
+      });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/apps/example-nest/src/app/post.controller.withResponseShapes.ts
+++ b/apps/example-nest/src/app/post.controller.withResponseShapes.ts
@@ -29,7 +29,7 @@ export class PostController  {
     });
 
     return {
-      status: 200 as const,
+      status: 200,
       body: { posts, count: totalPosts, skip, take },
     };
   }
@@ -40,10 +40,10 @@ export class PostController  {
     const post = await this.postService.getPost(id);
 
     if (!post) {
-      return { status: 404 as const, body: null };
+      return { status: 404, body: null };
     }
 
-    return { status: 200 as const, body: post };
+    return { status: 200, body: post };
   }
 
   @Api(s.route.createPost)
@@ -56,7 +56,7 @@ export class PostController  {
       description: body.description,
     });
 
-    return { status: 201 as const, body: post };
+    return { status: 201, body: post };
   }
 
   @Api(s.route.updatePost)
@@ -70,7 +70,7 @@ export class PostController  {
       description: body.description,
     });
 
-    return { status: 200 as const, body: post };
+    return { status: 200, body: post };
   }
 
   @Api(s.route.deletePost)
@@ -79,13 +79,13 @@ export class PostController  {
   ): Promise<ResponseShapes['deletePost']> {
     await this.postService.deletePost(id);
 
-    return { status: 200 as const, body: { message: 'Post Deleted' } };
+    return { status: 200, body: { message: 'Post Deleted' } };
   }
 
   @Api(s.route.testPathParams)
   async testPathParams(
     @ApiDecorator() { params }: RouteShape['testPathParams']
   ): Promise<ResponseShapes['testPathParams']> {
-    return { status: 200 as const, body: params };
+    return { status: 200, body: params };
   }
 }

--- a/apps/example-nest/src/app/post.controller.withResponseShapes.ts
+++ b/apps/example-nest/src/app/post.controller.withResponseShapes.ts
@@ -4,12 +4,13 @@ import { Api, ApiDecorator, initNestServer } from '@ts-rest/nest';
 import { PostService } from './post.service';
 
 const s = initNestServer(apiBlog);
-type ControllerShape = typeof s.controllerShape;
 type RouteShape = typeof s.routeShapes;
+type ResponseShapes = typeof s.responseShapes;
 
-// You can implement the ControllerShape interface to ensure type safety
+// Alternatively, you can the use the ResponseShapes type to ensure type safety
+
 @Controller()
-export class PostController implements ControllerShape {
+export class PostController  {
   constructor(private readonly postService: PostService) {}
 
   @Get('/test')
@@ -20,7 +21,7 @@ export class PostController implements ControllerShape {
   @Api(s.route.getPosts)
   async getPosts(
     @ApiDecorator() { query: { take, skip, search } }: RouteShape['getPosts']
-  ) {
+  ): Promise<ResponseShapes['getPosts']> {
     const { posts, totalPosts } = await this.postService.getPosts({
       take,
       skip,
@@ -34,7 +35,8 @@ export class PostController implements ControllerShape {
   }
 
   @Api(s.route.getPost)
-  async getPost(@ApiDecorator() { params: { id } }: RouteShape['getPost']) {
+  async getPost(@ApiDecorator() { params: { id } }: RouteShape['getPost']):
+    Promise<ResponseShapes['getPost']> {
     const post = await this.postService.getPost(id);
 
     if (!post) {
@@ -45,7 +47,8 @@ export class PostController implements ControllerShape {
   }
 
   @Api(s.route.createPost)
-  async createPost(@ApiDecorator() { body }: RouteShape['createPost']) {
+  async createPost(@ApiDecorator() { body }: RouteShape['createPost']): 
+    Promise<ResponseShapes['createPost']> {
     const post = await this.postService.createPost({
       title: body.title,
       content: body.content,
@@ -59,7 +62,7 @@ export class PostController implements ControllerShape {
   @Api(s.route.updatePost)
   async updatePost(
     @ApiDecorator() { params: { id }, body }: RouteShape['updatePost']
-  ) {
+  ): Promise<ResponseShapes['updatePost']> {
     const post = await this.postService.updatePost(id, {
       title: body.title,
       content: body.content,
@@ -73,7 +76,7 @@ export class PostController implements ControllerShape {
   @Api(s.route.deletePost)
   async deletePost(
     @ApiDecorator() { params: { id } }: RouteShape['deletePost']
-  ) {
+  ): Promise<ResponseShapes['deletePost']> {
     await this.postService.deletePost(id);
 
     return { status: 200 as const, body: { message: 'Post Deleted' } };
@@ -82,7 +85,7 @@ export class PostController implements ControllerShape {
   @Api(s.route.testPathParams)
   async testPathParams(
     @ApiDecorator() { params }: RouteShape['testPathParams']
-  ) {
+  ): Promise<ResponseShapes['testPathParams']> {
     return { status: 200 as const, body: params };
   }
 }

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -67,6 +67,20 @@ export type ApiRouteResponse<T> =
       body: unknown;
     };
 
+export type ApiResponseForRoute<T extends AppRoute> =
+  | {
+      [K in keyof T['responses']]: {
+        status: K
+        body: ZodInferOrType<T['responses'][K]>
+      }
+    }[keyof T['responses']]
+  & {
+      status: Exclude<HTTPStatusCode, keyof T>
+      body: unknown
+    };
+
+
+
 /**
  * Returned from a mutation or query call
  */
@@ -225,3 +239,13 @@ export const initClient = <T extends AppRouter>(
 
   return proxy as InitClientReturn<T>;
 };
+
+// takes a router and returns response types for each AppRoute
+// does not support nested routers, yet
+
+export function getRouteResponses<T extends AppRouter>(router: T) {
+  return {} as {
+     [K in keyof typeof router]: 
+        typeof router[K] extends AppRoute ? ApiResponseForRoute<typeof router[K]> : 'not a route'
+   }
+}

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -67,18 +67,7 @@ export type ApiRouteResponse<T> =
       body: unknown;
     };
 
-export type ApiResponseForRoute<T extends AppRoute> =
-  | {
-      [K in keyof T['responses']]: {
-        status: K
-        body: ZodInferOrType<T['responses'][K]>
-      }
-    }[keyof T['responses']]
-  & {
-      status: Exclude<HTTPStatusCode, keyof T>
-      body: unknown
-    };
-
+export type ApiResponseForRoute<T extends AppRoute> = ApiRouteResponse<T['responses']>
 
 
 /**

--- a/libs/ts-rest/nest/src/lib/ts-rest-nest.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest-nest.ts
@@ -1,4 +1,4 @@
-import { AppRoute, AppRouter, ApiRouteResponse, Without } from '@ts-rest/core';
+import { AppRoute, AppRouter, ApiRouteResponse, Without, getRouteResponses } from '@ts-rest/core';
 import { ApiDecoratorShape } from './api.decorator';
 
 type AppRouterMethodShape<T extends AppRoute> = (
@@ -32,6 +32,7 @@ export const initNestServer = <T extends AppRouter>(router: T) => {
   return {
     controllerShape: {} as NestControllerShapeFromAppRouter<T>,
     routeShapes: {} as NestAppRouteShape<T>,
+    responseShapes: getRouteResponses(router),
     route: router,
   };
 };


### PR DESCRIPTION
Per discussion on Discord, this feature allows users to extract response types from a given Contract. This is particularly useful for backend services where you want to avoid implementing an interface. 

I aimed to make this as non-intrusive as possible! All tests pass. Please read the modified Docs to get a feel for the changes/additions, and then you can look at `client.ts` to see the entry point of the implementation. 

Here's a screenshot of how it works:

<img width="930" alt="Screenshot 2022-12-23 at 1 26 32 PM" src="https://user-images.githubusercontent.com/55844504/209402950-2611267c-f1a1-4e0d-9e54-298c2da7b39e.png">
