### PR TITLE
Optional JSON-encoded query parameters

### DIFF
--- a/.changeset/silly-cameras-confess.md
+++ b/.changeset/silly-cameras-confess.md
@@ -1,0 +1,11 @@
+---
+'@ts-rest/core': minor
+'@ts-rest/express': minor
+'@ts-rest/nest': minor
+'@ts-rest/next': minor
+'@ts-rest/open-api': minor
+'@ts-rest/react-query': minor
+'@ts-rest/solid-query': minor
+---
+
+Allow typed query parameters by encoding them as JSON strings (disabled by default)

--- a/apps/docs/docs/core/core.md
+++ b/apps/docs/docs/core/core.md
@@ -39,6 +39,27 @@ export const contract = c.router({
 });
 ```
 
+## Query Parameters
+
+All query parameters, by default, need to have an input type of `string` since query strings inherently cannot be typed, however, ts-rest allows you to encode query parameters as JSON values.
+This will allow you to use input types other than strings in your contracts.
+
+```typescript
+const c = initContract();
+export const contract = c.router({
+    getPosts: {
+        ...,
+        query: z.object({
+            take: z.number().default(10),
+            skip: z.number().default(0),
+            search: z.string().optional(),
+        }),
+    }
+});
+```
+
+Check the relevant sections to see how to enable JSON query encoding/decoding on the client or server.
+
 ## Combining Contracts
 
 You can combine contracts to create a single contract, helpful if you want many sub contracts, especially if they are huge.

--- a/apps/docs/docs/core/fetch.md
+++ b/apps/docs/docs/core/fetch.md
@@ -9,7 +9,7 @@ export const client = initClient(router, {
 });
 ```
 
-### Query
+## Query
 
 **Query** against the contract, a _query_ is a function that does a GET request to the api.
 
@@ -17,7 +17,44 @@ export const client = initClient(router, {
 const { data } = await client.posts.get();
 ```
 
-### Mutate
+### Typed Query Parameters
+
+By default, all query parameters are encoded as strings, however, you can use the `jsonQuery` option to encode query parameters as typed JSON values.
+Make sure to enable JSON query handling on the server as well.
+
+```typescript
+const client = initClient(router, {
+  baseUrl: 'http://localhost:3334',
+  baseHeaders: {},
+  jsonQuery: true,
+});
+
+const { data } = await client.posts.get({
+  query: {
+    take: 10,
+    skip: 0,
+    search: 'hello',
+  },
+});
+```
+
+:::caution
+
+Objects implementing `.toJSON()` will irreversibly be converted to JSON, so you will need to use custom zod transforms to convert back to the original object types.
+
+For example, Date objects will be converted ISO strings by default, so you could handle this case like so:
+
+```typescript
+const dateSchema = z
+  .union([z.string().datetime(), z.date()])
+  .transform((date) => (typeof date === 'string' ? new Date(date) : date));
+```
+
+This will ensure that you could pass Date objects in your client queries. They will be converted to ISO strings in the JSON-encoded URL query string, and then converted back to Date objects on the server by zod's parser.
+
+:::
+
+## Mutate
 
 **Mutate** against the contract, a _mutation_ is a function that does a POST, PUT, PATCH or DELETE request to the api.
 
@@ -43,7 +80,7 @@ if (status === 200) {
 }
 ```
 
-### Return type
+## Return type
 
 ```typescript
 const data: {

--- a/apps/docs/docs/express.md
+++ b/apps/docs/docs/express.md
@@ -18,3 +18,11 @@ createExpressEndpoints(router, completeRouter, app);
 ```
 
 `createExpressEndpoints` is a function that takes a router and a complete router, and creates endpoints, with the correct methods, paths and callbacks.
+
+### JSON Query Parameters
+
+To handle JSON query parameters, you can use the `jsonQuery` option.
+
+```typescript
+createExpressEndpoints(router, completeRouter, app, { jsonQuery: true });
+```

--- a/apps/docs/docs/nest.md
+++ b/apps/docs/docs/nest.md
@@ -28,6 +28,34 @@ The `@Api` decorator takes the route, defines the path and method for the contro
 
 It also injects "appRoute" into the req object, allowing the `@ApiDecorator` decorator automatically parse and check the query and body parameters.
 
+### JSON Query Parameters
+
+To handle JSON query parameters, you can use the `@JsonQuery()` decorator on either your Controller classes or individual endpoint methods.
+
+```typescript
+@Controller()
+@JsonQuery()
+export class PostController implements ControllerShape {}
+
+```
+
+The method decorator can be useful to override the controller's behaviour on a per-endpoint basis.
+
+```typescript
+
+@Controller()
+@JsonQuery()
+export class PostController implements ControllerShape {
+  constructor(private readonly postService: PostService) {}
+
+  @Api(s.route.getPost)
+  @JsonQuery(false)
+  async getPost(@ApiDecorator() { params: { id } }: RouteShape['getPost']) {
+    // ...
+  }
+}
+```
+
 :::caution
 
 Currently any existing Nest global prefix, versioning, or controller prefixes will be ignored, please see https://github.com/ts-rest/ts-rest/issues/70 for more details.

--- a/apps/docs/docs/next.md
+++ b/apps/docs/docs/next.md
@@ -30,6 +30,14 @@ export default createNextRouter(api, router);
 
 `createNextRouter` is a function that takes a router and a complete router, and creates endpoints, with the correct methods, paths and callbacks.
 
+### JSON Query Parameters
+
+To handle JSON query parameters, you can use the `jsonQuery` option.
+
+```typescript
+export default createNextRouter(api, router, { jsonQuery: true });
+```
+
 ## Future Work
 
 As this pattern doesn't support a lambda per endpoint, it is planned to provide a helper utility to allow individual endpoints to be created.

--- a/apps/docs/docs/react-query.md
+++ b/apps/docs/docs/react-query.md
@@ -35,6 +35,18 @@ const App = () => {
 };
 ```
 
+### JSON Query Parameters
+
+To enable encoding query parameters as typed JSON values, you can use the `jsonQuery` option.
+
+```typescript
+export const client = initQueryClient(router, {
+  baseUrl: 'http://localhost:3333',
+  baseHeaders: {},
+  jsonQuery: true,
+});
+```
+
 ## Regular Query and Mutations
 
 `@ts-rest/react-query` allows for a regular fetch or mutation if you want, without having to initialise two different clients, one with `@ts-rest/core` and one with `@ts-react/react-query`.

--- a/apps/example-express/src/main.ts
+++ b/apps/example-express/src/main.ts
@@ -94,7 +94,7 @@ app.get('/test', (req, res) => {
 });
 
 createExpressEndpoints(apiBlog, completedRouter, app);
-createExpressEndpoints(contractTs, tsRouter, app);
+createExpressEndpoints(contractTs, tsRouter, app, { jsonQuery: true });
 
 const port = process.env.port || 3333;
 const server = app.listen(port, () => {

--- a/apps/example-express/src/tests/ts-posts.spec.ts
+++ b/apps/example-express/src/tests/ts-posts.spec.ts
@@ -5,9 +5,17 @@ const superTestApp = supertest(app);
 
 describe('TS Posts Endpoints', () => {
   it('GET /posts/1 should return a post', async () => {
-    const res = await superTestApp.get('/ts/posts/123?skip=0&take=10');
+    const res = await superTestApp.get('/ts/posts/123');
 
     expect(res.status).toStrictEqual(200);
     expect(res.body.id).toStrictEqual('123'); // Not "123" as a number, because no Zod transform
+  });
+
+  it('GET /posts should return posts with typed query params', async () => {
+    const res = await superTestApp.get('/ts/posts?skip=42&take=100');
+
+    expect(res.status).toStrictEqual(200);
+    expect(res.body.skip).toStrictEqual(42);
+    expect(res.body.take).toStrictEqual(100);
   });
 });

--- a/apps/example-express/src/ts-router.ts
+++ b/apps/example-express/src/ts-router.ts
@@ -28,4 +28,20 @@ export const tsRouter = s.router(contractTs, {
       body: post,
     };
   },
+  getPosts: async ({ query }) => {
+    const posts = [
+      mockPostFixtureFactory({ id: '1' }),
+      mockPostFixtureFactory({ id: '2' }),
+    ];
+
+    return {
+      status: 200,
+      body: {
+        posts,
+        count: 0,
+        skip: query.skip || 0,
+        take: query.take || 50,
+      },
+    };
+  },
 });

--- a/apps/example-nest/src/app/app.module.ts
+++ b/apps/example-nest/src/app/app.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 
 import { PostController } from './post.controller';
+import { PostJsonQueryController } from './post-json-query.controller';
 import { PrismaService } from './prisma.service';
 import { PostService } from './post.service';
 
 @Module({
   imports: [],
-  controllers: [PostController],
+  controllers: [PostController, PostJsonQueryController],
   providers: [PrismaService, PostService],
 })
 export class AppModule {}

--- a/apps/example-nest/src/app/post-json-query.controller.ts
+++ b/apps/example-nest/src/app/post-json-query.controller.ts
@@ -1,0 +1,41 @@
+import { Controller } from '@nestjs/common';
+import { apiBlog } from '@ts-rest/example-contracts';
+import { Api, ApiDecorator, initNestServer, JsonQuery } from '@ts-rest/nest';
+import { z } from 'zod';
+import { PostService } from './post.service';
+
+const s = initNestServer({
+  getPosts: {
+    ...apiBlog.getPosts,
+    path: '/posts-json-query',
+    query: z.object({
+      take: z.number().default(50),
+      skip: z.number().default(0),
+      search: z.string().optional(),
+    }),
+  },
+});
+type ControllerShape = typeof s.controllerShape;
+type RouteShape = typeof s.routeShapes;
+
+@JsonQuery()
+@Controller()
+export class PostJsonQueryController implements ControllerShape {
+  constructor(private readonly postService: PostService) {}
+
+  @Api(s.route.getPosts)
+  async getPosts(
+    @ApiDecorator() { query: { take, skip, search } }: RouteShape['getPosts']
+  ) {
+    const { posts, totalPosts } = await this.postService.getPosts({
+      take,
+      skip,
+      search,
+    });
+
+    return {
+      status: 200 as const,
+      body: { posts, count: totalPosts, skip, take },
+    };
+  }
+}

--- a/apps/example-nest/src/app/post-json-query.spec.ts
+++ b/apps/example-nest/src/app/post-json-query.spec.ts
@@ -1,0 +1,57 @@
+import { PostService } from './post.service';
+import { Test } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { Post } from '@prisma/client';
+import * as request from 'supertest';
+import { PostJsonQueryController } from './post-json-query.controller';
+
+describe('PostJsonQueryController', () => {
+  let app: INestApplication;
+  let postService: PostService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [PostJsonQueryController],
+      providers: [
+        {
+          provide: PostService,
+          useValue: {
+            getPosts: jest.fn(),
+            createPost: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    postService = moduleRef.get<PostService>(PostService);
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  describe('GET /posts-json-query', () => {
+    it('should correctly parse number values', async () => {
+      jest
+        .spyOn(postService, 'getPosts')
+        .mockImplementation(async ({ search }) => ({
+          posts: [{ title: search } as Post],
+          totalPosts: 1,
+        }));
+
+      return request(app.getHttpServer())
+        .get('/posts-json-query')
+        .query('skip=0&take=10&search="foo"')
+        .expect(200)
+        .expect({
+          posts: [{ title: 'foo' }],
+          count: 1,
+          skip: 0,
+          take: 10,
+        });
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/apps/example-nest/src/app/post.controller.spec.ts
+++ b/apps/example-nest/src/app/post.controller.spec.ts
@@ -30,13 +30,18 @@ describe('PostController', () => {
 
   describe('GET /posts', () => {
     it('should transform skip and take into numbers', async () => {
-      jest.spyOn(postService, 'getPosts').mockResolvedValue([] as any);
+      jest.spyOn(postService, 'getPosts').mockResolvedValue({
+        posts: [],
+        totalPosts: 0,
+      });
 
       return request(app.getHttpServer())
         .get('/posts')
         .query('skip=0&take=10')
         .expect(200)
         .expect({
+          posts: [],
+          count: 0,
           skip: 0,
           take: 10,
         });

--- a/libs/example-contracts/src/lib/contract-ts.ts
+++ b/libs/example-contracts/src/lib/contract-ts.ts
@@ -1,4 +1,5 @@
 import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
 
 export interface PostTs {
   id: string;
@@ -34,5 +35,23 @@ export const contractTs = c.router({
     },
     query: null,
     summary: 'Get a post by id',
+  },
+  getPosts: {
+    method: 'GET',
+    path: `/ts/posts`,
+    responses: {
+      200: c.response<{
+        posts: PostTs[];
+        count: number;
+        skip: number;
+        take: number;
+      }>(),
+    },
+    query: z.object({
+      take: z.number().optional(),
+      skip: z.number().optional(),
+      search: z.string().optional(),
+    }),
+    summary: 'Get all posts',
   },
 });

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -37,6 +37,7 @@ const postsRouter = c.router({
     query: z.object({
       take: z.number().optional(),
       skip: z.number().optional(),
+      order: z.string().optional(),
     }),
   },
   createPost: {
@@ -120,7 +121,7 @@ export const router = c.router({
 const api = jest.fn();
 
 const client = initClient(router, {
-  baseUrl: 'http://api.com',
+  baseUrl: 'https://api.com',
   baseHeaders: {},
   api,
 });
@@ -141,7 +142,7 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'GET',
-        path: 'http://api.com/posts',
+        path: 'https://api.com/posts',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -159,7 +160,7 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'GET',
-        path: 'http://api.com/posts',
+        path: 'https://api.com/posts',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -177,7 +178,59 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'GET',
-        path: 'http://api.com/posts?take=10',
+        path: 'https://api.com/posts?take=10',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: undefined,
+      });
+    });
+
+    it('w/ json query parameters', async () => {
+      const api = jest.fn();
+      const client = initClient(
+        {
+          ...router,
+          posts: {
+            ...router.posts,
+            getPosts: {
+              ...router.posts.getPosts,
+              query: router.posts.getPosts.query.extend({
+                published: z.boolean(),
+                filter: z.object({
+                  title: z.string(),
+                }),
+              }),
+            },
+          },
+        },
+        {
+          baseUrl: 'https://api.com',
+          baseHeaders: {},
+          jsonQuery: true,
+          api,
+        }
+      );
+
+      const value = { key: 'value' };
+      api.mockResolvedValue({ body: value, status: 200 });
+
+      const result = await client.posts.getPosts({
+        query: {
+          take: 10,
+          order: 'asc',
+          published: true,
+          filter: { title: 'test' },
+        },
+      });
+
+      expect(result).toStrictEqual({ body: value, status: 200 });
+
+      expect(api).toHaveBeenCalledWith({
+        method: 'GET',
+        path: `https://api.com/posts?take=10&order=asc&published=true&filter=${encodeURIComponent(
+          '{"title":"test"}'
+        )}`,
         headers: {
           'Content-Type': 'application/json',
         },
@@ -197,7 +250,7 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'GET',
-        path: 'http://api.com/posts?take=10',
+        path: 'https://api.com/posts?take=10',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -215,7 +268,7 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'GET',
-        path: 'http://api.com/posts/1',
+        path: 'https://api.com/posts/1',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -237,7 +290,7 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'POST',
-        path: 'http://api.com/posts',
+        path: 'https://api.com/posts',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -262,7 +315,7 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'PUT',
-        path: 'http://api.com/posts/1',
+        path: 'https://api.com/posts/1',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -286,7 +339,7 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'POST',
-        path: 'http://api.com/posts?test=test',
+        path: 'https://api.com/posts?test=test',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -309,7 +362,7 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'PUT',
-        path: 'http://api.com/posts/1',
+        path: 'https://api.com/posts/1',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -336,7 +389,7 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'PATCH',
-        path: 'http://api.com/posts/1',
+        path: 'https://api.com/posts/1',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -359,7 +412,7 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'DELETE',
-        path: 'http://api.com/posts/1',
+        path: 'https://api.com/posts/1',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -386,7 +439,7 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'POST',
-        path: 'http://api.com/upload',
+        path: 'https://api.com/upload',
         headers: {},
         body: expectedFormData,
       });
@@ -408,7 +461,7 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'POST',
-        path: 'http://api.com/upload',
+        path: 'https://api.com/upload',
         headers: {},
         body: formData,
       });

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -142,7 +142,7 @@ describe('client', () => {
 
       expect(api).toHaveBeenCalledWith({
         method: 'GET',
-        path: 'http://api.com/posts',
+        path: 'https://api.com/posts',
         headers: {
           'Content-Type': 'application/json',
         },

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -84,6 +84,7 @@ export interface ClientArgs {
   baseHeaders: Record<string, string>;
   api?: ApiFetcher;
   credentials?: RequestCredentials;
+  jsonQuery?: boolean;
 }
 
 type ApiFetcher = (args: {
@@ -167,13 +168,14 @@ export const getCompleteUrl = (
   query: unknown,
   baseUrl: string,
   params: unknown,
-  route: AppRoute
+  route: AppRoute,
+  jsonQuery: boolean
 ) => {
   const path = insertParamsIntoPath({
     path: route.path,
     params: params as any,
   });
-  const queryComponent = convertQueryParamsToUrlString(query);
+  const queryComponent = convertQueryParamsToUrlString(query, jsonQuery);
   return `${baseUrl}${path}${queryComponent}`;
 };
 
@@ -186,7 +188,8 @@ export const getRouteQuery = <TAppRoute extends AppRoute>(
       inputArgs?.query,
       clientArgs.baseUrl,
       inputArgs?.params,
-      route
+      route,
+      !!clientArgs.jsonQuery
     );
 
     return await fetchApi(completeUrl, clientArgs, route, inputArgs?.body);

--- a/libs/ts-rest/nest/src/index.ts
+++ b/libs/ts-rest/nest/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/ts-rest-nest';
 export * from './lib/api.decorator';
+export * from './lib/json-query.decorator';

--- a/libs/ts-rest/nest/src/lib/json-query.decorator.ts
+++ b/libs/ts-rest/nest/src/lib/json-query.decorator.ts
@@ -1,0 +1,9 @@
+export const JsonQuerySymbol = Symbol('JsonQuery');
+
+export const JsonQuery = (
+  jsonQuery = true
+): ClassDecorator & MethodDecorator => {
+  return (target: object) => {
+    Reflect.defineMetadata(JsonQuerySymbol, jsonQuery, target);
+  };
+};

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
@@ -80,7 +80,7 @@ const expectedApiDoc = {
     title: 'Blog API',
     version: '0.1',
   },
-  openapi: '3.0.0',
+  openapi: '3.0.2',
   paths: {
     '/health': {
       get: {
@@ -307,6 +307,89 @@ describe('ts-rest-open-api', () => {
             get: {
               ...expectedApiDoc.paths['/posts/{id}/comments'].get,
               operationId: 'getPostComments',
+            },
+          },
+        },
+      });
+    });
+
+    it('should generate doc with json query', async () => {
+      const apiDoc = generateOpenApi(
+        router,
+        {
+          info: { title: 'Blog API', version: '0.1' },
+        },
+        { jsonQuery: true }
+      );
+
+      expect(apiDoc).toEqual({
+        ...expectedApiDoc,
+        paths: {
+          ...expectedApiDoc.paths,
+          '/posts': {
+            ...expectedApiDoc.paths['/posts'],
+            get: {
+              ...expectedApiDoc.paths['/posts'].get,
+              parameters: [
+                {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        anyOf: [
+                          {
+                            not: {},
+                          },
+                          {
+                            type: 'string',
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  in: 'query',
+                  name: 'search',
+                },
+                {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        anyOf: [
+                          {
+                            not: {},
+                          },
+                          {
+                            default: 'date',
+                            enum: ['title', 'date'],
+                            type: 'string',
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  in: 'query',
+                  name: 'sortBy',
+                },
+                {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        anyOf: [
+                          {
+                            not: {},
+                          },
+                          {
+                            default: 'asc',
+                            enum: ['asc', 'desc'],
+                            type: 'string',
+                          },
+                        ],
+                      },
+                    },
+                  },
+                  in: 'query',
+                  name: 'sort',
+                },
+              ],
             },
           },
         },

--- a/libs/ts-rest/react-query/src/lib/react-query.ts
+++ b/libs/ts-rest/react-query/src/lib/react-query.ts
@@ -185,7 +185,8 @@ const getRouteUseQuery = <TAppRoute extends AppRoute>(
         args?.query,
         clientArgs.baseUrl,
         args?.params,
-        route
+        route,
+        !!clientArgs.jsonQuery
       );
 
       const result = await fetchApi(path, clientArgs, route, args?.body);
@@ -220,7 +221,8 @@ const getRouteUseInfiniteQuery = <TAppRoute extends AppRoute>(
         resultingQueryArgs.query,
         clientArgs.baseUrl,
         resultingQueryArgs.params,
-        route
+        route,
+        !!clientArgs.jsonQuery
       );
 
       const result = await fetchApi(
@@ -252,7 +254,8 @@ const getRouteUseMutation = <TAppRoute extends AppRoute>(
         args?.query,
         clientArgs.baseUrl,
         args?.params,
-        route
+        route,
+        !!clientArgs.jsonQuery
       );
 
       const result = await fetchApi(path, clientArgs, route, args?.body);

--- a/libs/ts-rest/solid-query/src/lib/solid-query.ts
+++ b/libs/ts-rest/solid-query/src/lib/solid-query.ts
@@ -156,7 +156,8 @@ const getRouteUseQuery = <TAppRoute extends AppRoute>(
         args.query,
         clientArgs.baseUrl,
         args.params,
-        route
+        route,
+        !!clientArgs.jsonQuery
       );
 
       const result = await fetchApi(path, clientArgs, route, args.body);
@@ -191,7 +192,8 @@ const getRouteUseInfiniteQuery = <TAppRoute extends AppRoute>(
         resultingQueryArgs.query,
         clientArgs.baseUrl,
         resultingQueryArgs.params,
-        route
+        route,
+        !!clientArgs.jsonQuery
       );
 
       const result = await fetchApi(
@@ -223,7 +225,8 @@ const getRouteUseMutation = <TAppRoute extends AppRoute>(
         args.query,
         clientArgs.baseUrl,
         args.params,
-        route
+        route,
+        !!clientArgs.jsonQuery
       );
 
       const result = await fetchApi(path, clientArgs, route, args.body);


### PR DESCRIPTION
Now the library can truly claim to offer "Fully typed RPC-like client"

I think the main point of discussion would be the opinionated approach of the selective encoding format of root-level strings.

The implementation, as is, will not JSON encode (i.e. surround with double quotes) a root-level string unless it clashes with a JSON reserved word or is a number.

```typescript
const query = { foo: 'foo', nested: { bar: 'bar' }  };
// ?foo=foo&nested={"bar":"bar"}

const query = { foo: 'true' };
// ?foo="true"

const query = { foo: true };
// ?foo=true

const query = { foo: '123' };
// ?foo="123"

const query = { foo: 123 };
// ?foo=123
```

I think it's nice because this leaves the URL looking like regular query strings in the majority of use cases. This is also how swagger encodes root-level strings even if we specify the MIME type as `application/json`

![Screenshot 2022-12-29 062946](https://user-images.githubusercontent.com/1728215/209903773-93a521e0-d5da-4421-bf25-53a9ebe2eeb6.png)
