### PR TITLE
Fix typing for query

### DIFF
--- a/.changeset/swift-points-brush.md
+++ b/.changeset/swift-points-brush.md
@@ -1,0 +1,6 @@
+---
+'@ts-rest/core': patch
+'@ts-rest/react-query': patch
+---
+
+Fix typing for query

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -135,6 +135,24 @@ describe('client', () => {
       const value = { key: 'value' };
       api.mockResolvedValue({ body: value, status: 200 });
 
+      const result = await client.posts.getPosts({});
+
+      expect(result).toStrictEqual({ body: value, status: 200 });
+
+      expect(api).toHaveBeenCalledWith({
+        method: 'GET',
+        path: 'http://api.com/posts',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: undefined,
+      });
+    });
+
+    it('w/ no query parameters', async () => {
+      const value = { key: 'value' };
+      api.mockResolvedValue({ body: value, status: 200 });
+
       const result = await client.posts.getPosts({ query: {} });
 
       expect(result).toStrictEqual({ body: value, status: 200 });

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -6,6 +6,7 @@ import { HTTPStatusCode } from './status-codes';
 import {
   AreAllPropertiesOptional,
   Merge,
+  OptionalIfAllOptional,
   Without,
   ZodInferOrType,
 } from './type-utils';
@@ -43,17 +44,19 @@ type AppRouteBodyOrFormData<T extends AppRouteMutation> =
     ? FormData | AppRouteMutationType<T['body']>
     : AppRouteMutationType<T['body']>;
 
-interface DataReturnArgs<TRoute extends AppRoute> {
+interface DataReturnArgsBase<TRoute extends AppRoute> {
   body: TRoute extends AppRouteMutation
     ? AppRouteBodyOrFormData<TRoute>
     : never;
   params: PathParamsFromUrl<TRoute>;
-  query: AreAllPropertiesOptional<
-    AppRouteMutationType<TRoute['query']>
-  > extends false
+  query: 'query' extends keyof TRoute
     ? AppRouteMutationType<TRoute['query']>
     : never;
 }
+
+type DataReturnArgs<TRoute extends AppRoute> = OptionalIfAllOptional<
+  DataReturnArgsBase<TRoute>
+>;
 
 export type ApiRouteResponse<T> =
   | {

--- a/libs/ts-rest/core/src/lib/type-utils.ts
+++ b/libs/ts-rest/core/src/lib/type-utils.ts
@@ -89,8 +89,30 @@ type NarrowNotZod<T> = Try<T, ZodType, NarrowRaw<T>>;
 
 export type Narrow<T> = Try<T, [], NarrowNotZod<T>>;
 
-export type AreAllPropertiesOptional<T> = {
-  [K in keyof T]-?: undefined extends T[K] ? true : false;
-}[keyof T] extends true
-  ? true
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+// https://github.com/ts-essentials/ts-essentials/blob/4c451652ba7c20b0e0b965e0b7755fd4d7844127/lib/types.ts#L228
+type OptionalKeys<T> = T extends unknown
+  ? {
+      [K in keyof T]-?: undefined extends { [K2 in keyof T]: K2 }[K]
+        ? K
+        : never;
+    }[keyof T]
+  : never;
+
+export type AreAllPropertiesOptional<T> = T extends Record<string, unknown>
+  ? Exclude<keyof T, OptionalKeys<T>> extends never
+    ? true
+    : false
   : false;
+
+export type OptionalIfAllOptional<
+  T,
+  Select extends keyof T = keyof T
+> = PartialBy<
+  T,
+  Select &
+    {
+      [K in keyof T]: AreAllPropertiesOptional<T[K]> extends true ? K : never;
+    }[keyof T]
+>;


### PR DESCRIPTION
Looks like a small issue was introduced with the `AreAllPropertiesOptional` change. `query` was resolving to `never` if not all of its options were optional, but also for some reason the typing was still broken even they were all optional.

![Screenshot 2022-12-30 155037](https://user-images.githubusercontent.com/1728215/210116170-678831ae-fb8a-4b1a-96d3-2030259d9e89.png)

You can see here, typescript was not complaining at all, despite `null` not being an compatible value.