### PR TITLE
Publish README with all packages

### DIFF
--- a/.changeset/pink-pugs-jump.md
+++ b/.changeset/pink-pugs-jump.md
@@ -1,0 +1,11 @@
+---
+'@ts-rest/core': patch
+'@ts-rest/express': patch
+'@ts-rest/nest': patch
+'@ts-rest/next': patch
+'@ts-rest/open-api': patch
+'@ts-rest/react-query': patch
+'@ts-rest/solid-query': patch
+---
+
+Publish README

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Modify Workspace File
         run: sed -e "s;libs/;dist/libs/;g" package.json > package-new.json && mv package-new.json package.json
 
+      - name: Copy README.md to packages
+        run: find dist/libs/ts-rest -mindepth 1 -maxdepth 1 -type d -exec cp README.md '{}' ';'
+
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@master
         with:


### PR DESCRIPTION
The packages' [npm pages](https://www.npmjs.com/package/@ts-rest/core) are looking a little barren. This should help a bit with SEO.

Bumped the patch version to force the readme to be published.