### PR TITLE
fix: copy README.md after building during release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build
-        run: pnpm exec nx run-many --target build --all --parallel
-
       - name: Modify Workspace File
         run: sed -e "s;libs/;dist/libs/;g" package.json > package-new.json && mv package-new.json package.json
-
-      - name: Copy README.md to packages
-        run: find dist/libs/ts-rest -mindepth 1 -maxdepth 1 -type d -exec cp README.md '{}' ';'
 
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@master

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "scripts": {
     "version-packages": "changeset version",
-    "release": "pnpm nx run-many --target=build --exclude=example-expo && changeset publish",
+    "release": "pnpm nx run-many --target=build --exclude=example-expo && pnpm copy-readme && changeset publish",
+    "copy-readme": "find dist/libs/ts-rest -mindepth 1 -maxdepth 1 -type d -exec cp README.md '{}' ';'",
     "nest": "pnpm nx run example-nest:serve",
     "affected:all": "pnpm nx affected:lint && pnpm nx affected:test && pnpm nx affected:build",
     "docs:build": "pnpm nx run docs:build && ts-node ./tools/scripts/docs-redirects.ts",


### PR DESCRIPTION
Not creating a new release this time so we don't keep releasing unnecessary extra versions. Should go out with next release.