### PR TITLE
Revised Nest function and type names

### DIFF
--- a/.changeset/dull-maps-draw.md
+++ b/.changeset/dull-maps-draw.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/nest': minor
+---
+
+Rename some Nest functions and types, and deprecate old names

--- a/.changeset/dull-maps-draw.md
+++ b/.changeset/dull-maps-draw.md
@@ -6,3 +6,6 @@
 Rename some Nest functions and types, and deprecate old names
 
 Fix Nest deprecation warning when passing Zod error to HttpException (#122)
+
+Some internal helper types (`NestControllerShapeFromAppRouter` and `NestAppRouteShape`) that were previously exported are now kept internal.
+You can use `NestControllerInterface` and `NestRequestShapes` instead.

--- a/.changeset/dull-maps-draw.md
+++ b/.changeset/dull-maps-draw.md
@@ -1,5 +1,8 @@
 ---
 '@ts-rest/nest': minor
+'@ts-rest/core': patch
 ---
 
 Rename some Nest functions and types, and deprecate old names
+
+Fix Nest deprecation warning when passing Zod error to HttpException (#122)

--- a/README.md
+++ b/README.md
@@ -4,19 +4,24 @@
  <img src="https://avatars.githubusercontent.com/u/109956939?s=400&u=8bf67b1281da46d64eab85f48255cd1892bf0885&v=4" height="150"></img>
 </p>
 
- <p align="center">RPC-like client and server helpers for a magical end to end typed experience</p> 
- <p align="center">
-   <a href="https://www.npmjs.com/package/@ts-rest/core">
-   <img src="https://img.shields.io/npm/v/@ts-rest/core.svg" alt="langue typescript"/>
-   </a>
-   <a href="https://www.npmjs.com/package/@ts-rest/core"/>
-   <img alt="npm" src="https://img.shields.io/npm/dw/@ts-rest/core"/>
-     <a href="https://github.com/ts-rest/ts-rest/blob/main/LICENSE"></a>
-    <img alt="GitHub" src="https://img.shields.io/github/license/ts-rest/ts-rest"/> 
-   <img alt="GitHub Workflow Status" src="https://img.shields.io/bundlephobia/minzip/@ts-rest/core?label=%40ts-rest%2Fcore"/>
-   <img alt="GitHub Workflow Status" src="https://img.shields.io/discord/1055855205960392724"/>
-   
- </p>
+<p align="center">RPC-like client and server helpers for a magical end to end typed experience</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@ts-rest/core">
+    <img src="https://img.shields.io/npm/v/@ts-rest/core.svg" alt="langue typescript"/>
+  </a>
+  <img alt="Github Workflow Status" src="https://img.shields.io/github/actions/workflow/status/ts-rest/ts-rest/release.yml?branch=main"/>
+  <a href="https://www.npmjs.com/package/@ts-rest/core">
+    <img alt="npm" src="https://img.shields.io/npm/dw/@ts-rest/core"/>
+  </a>
+  <a href="https://github.com/ts-rest/ts-rest/blob/main/LICENSE">
+    <img alt="License" src="https://img.shields.io/github/license/ts-rest/ts-rest"/>
+  </a>
+  <img alt="Bundle Size" src="https://img.shields.io/bundlephobia/minzip/@ts-rest/core?label=%40ts-rest%2Fcore"/>
+  <a href="https://discord.com/invite/2Megk85k5a">  
+    <img alt="Discord" src="https://img.shields.io/discord/1055855205960392724"/>
+  </a>
+</p>
 
 # Introduction
 

--- a/apps/docs/docs/core/form-data.mdx
+++ b/apps/docs/docs/core/form-data.mdx
@@ -116,7 +116,7 @@ export class AppController implements NestControllerInterface<typeof c> {
   @Api(s.route.updateUserAvatar)
   @UseInterceptors(FileInterceptor('avatar'))
   async updateUserAvatar(
-    @TypedRequest() { params: { id } }: RequestShapes['updateUserAvatar'],
+    @TsRestRequest() { params: { id } }: RequestShapes['updateUserAvatar'],
     @UploadedFile() avatar: Express.Multer.File
   ) {
     return {

--- a/apps/docs/docs/core/form-data.mdx
+++ b/apps/docs/docs/core/form-data.mdx
@@ -112,11 +112,11 @@ With Nest this is a pretty simple implementation, due to the extensible Decorato
 ```ts
 // nest
 @Controller()
-export class AppController implements ControllerShape {
+export class AppController implements NestControllerInterface<typeof c> {
   @Api(s.route.updateUserAvatar)
   @UseInterceptors(FileInterceptor('avatar'))
   async updateUserAvatar(
-    @ApiDecorator() { params: { id } }: RouteShape['updateUserAvatar'],
+    @TypedRequest() { params: { id } }: RequestShapes['updateUserAvatar'],
     @UploadedFile() avatar: Express.Multer.File
   ) {
     return {

--- a/apps/docs/docs/nest.md
+++ b/apps/docs/docs/nest.md
@@ -1,19 +1,25 @@
 # Nest
 
-By default Nest doesn't offer a nice way to ensure type safe controllers, primarily because it's decorator driven rather than functional, like Express.
+As opposed to the Express implementation, where we can infer types from a function signature, we need to explicitly define our types since Nest controllers are implemented as classes.
 
 ```typescript
-const s = initNestServer(apiBlog);
-type ControllerShape = typeof s.controllerShape;
-type RouteShape = typeof s.routeShapes;
-type ResponseShapes = typeof s.responseShapes;
+import {
+  Api,
+  nestControllerContract,
+  NestControllerInterface,
+  NestRequestShapes,
+  TypedRequest,
+} from '@ts-rest/nest';
+
+const c = nestControllerContract(apiBlog);
+type RequestShapes = NestRequestShapes<typeof c>;
 
 @Controller()
-export class PostController implements ControllerShape {
+export class PostController implements NestControllerInterface<typeof c> {
   constructor(private readonly postService: PostService) {}
 
-  @Api(s.route.getPost)
-  async getPost(@ApiDecorator() { params: { id } }: RouteShape['getPost']) {
+  @Api(c.getPost)
+  async getPost(@TypedRequest() { params: { id } }: RequestShapes['getPost']) {
     const post = await this.postService.getPost(id);
 
     if (!post) {
@@ -25,9 +31,17 @@ export class PostController implements ControllerShape {
 }
 ```
 
+The `nestControllerContract` filters your contract to only include immediate routes and no nested routes. Otherwise, you'd have to implement the entire contract in a single controller. As a result, it's good practice to design your contract into multiple nested contracts, one for each controller.
+
+To implement a nested contract, you can simply call `nestControllerContract(contract.nestedContract)`
+
+Having the controller class implement `NestControllerInterface` ensures that your controller implements all the routes defined in the contract. In addition, it ensures the type safety of the responses returned.
+
 The `@Api` decorator takes the route, defines the path and method for the controller route.
 
-It also injects "appRoute" into the req object, allowing the `@ApiDecorator` decorator automatically parse and check the query and body parameters.
+The `@TypedRequest` decorator takes the contract route defined in the `@Api` decorator, and returns the parsed and validated (if using Zod) request params, query and body.
+
+As Typescript cannot infer class method parameter types from an implemented interface, we need to explicitly define the type for the request parameter using the `NestRequestShapes` type. 
 
 ## JSON Query Parameters
 
@@ -36,7 +50,7 @@ To handle JSON query parameters, you can use the `@JsonQuery()` decorator on eit
 ```typescript
 @Controller()
 @JsonQuery()
-export class PostController implements ControllerShape {}
+export class PostController implements NestControllerInterface<typeof c> {}
 ```
 
 The method decorator can be useful to override the controller's behaviour on a per-endpoint basis.
@@ -44,55 +58,53 @@ The method decorator can be useful to override the controller's behaviour on a p
 ```typescript
 @Controller()
 @JsonQuery()
-export class PostController implements ControllerShape {
+export class PostController implements NestControllerInterface<typeof c> {
   constructor(private readonly postService: PostService) {}
 
   @Api(s.route.getPost)
   @JsonQuery(false)
-  async getPost(@ApiDecorator() { params: { id } }: RouteShape['getPost']) {
+  async getPost(@TypedRequest() { params: { id } }: RequestShapes['getPost']) {
     // ...
   }
 }
 ```
 
-## Response Return Type Safety
+## Explicit Response Type Safety
 
-You have two options to ensure HTTP type safety on your Nest Controllers:
+In cases where you do not want to implement `NestControllerInterface`.
+Say, if you were to implement a contract's non-nested routes across multiple controllers, or use different class method names than the ones defined in your contract, you can still ensure type safety of the responses by using the `NestResponseShapes` type.
 
-- `ControllerShape` as shown above:
-  - Your controller can implement the `ControllerShape` derived from `typeof s.controllerShape`
-  - This ensures your controller methods also align with the base interface shapes
-- `ResponseShapes`:
+```typescript
+import {
+  Api,
+  nestControllerContract,
+  NestRequestShapes,
+  NestResponseShapes,
+  TypedRequest,
+} from '@ts-rest/nest';
 
-  - Your controller can utilize `typeof s.responseShapes` in the return type. For example:
+const c = nestControllerContract(apiBlog);
+type RequestShapes = NestRequestShapes<typeof c>;
+type ResponseShapes = NestResponseShapes<typeof c>;
 
-    ```typescript
-    const s = initNestServer(apiBlog);
-    type ControllerShape = typeof s.controllerShape;
-    type RouteShape = typeof s.routeShapes;
-    type ResponseShapes = typeof s.responseShapes; // <- http Responses defined in contract
+@Controller()
+export class PostController {
+  constructor(private readonly postService: PostService) {}
 
-    @Controller()
-    export class PostController {
-      constructor(private readonly postService: PostService) {}
+  @Api(c.getPost)
+  async getPost(
+    @TypedRequest() { params: { id } }: RequestShapes['getPost']
+  ): Promise<ResponseShapes['getPost']> {
+    const post = await this.postService.getPost(id);
 
-      @Api(s.route.getPost)
-      async getPost(
-        @ApiDecorator() { params: { id } }: RouteShape['getPost']
-      ): Promise<ResponseShapes['getPost']> {
-        // <- return type defined here
-        const post = await this.postService.getPost(id);
-
-        if (!post) {
-          return { status: 404, body: null };
-        }
-
-        return { status: 200, body: post };
-      }
+    if (!post) {
+      return { status: 404 as const, body: null };
     }
-    ```
 
-  - If your controller needs to implement a difference class, or needs extra methods defined outside of a contract, this is option gives that flexibility without having to worry about maintaining class extensions.
+    return { status: 200 as const, body: post };
+  }
+}
+```
 
 :::caution
 

--- a/apps/docs/docs/nest.md
+++ b/apps/docs/docs/nest.md
@@ -8,7 +8,7 @@ import {
   nestControllerContract,
   NestControllerInterface,
   NestRequestShapes,
-  TypedRequest,
+  TsRestRequest,
 } from '@ts-rest/nest';
 
 const c = nestControllerContract(apiBlog);
@@ -19,7 +19,7 @@ export class PostController implements NestControllerInterface<typeof c> {
   constructor(private readonly postService: PostService) {}
 
   @Api(c.getPost)
-  async getPost(@TypedRequest() { params: { id } }: RequestShapes['getPost']) {
+  async getPost(@TsRestRequest() { params: { id } }: RequestShapes['getPost']) {
     const post = await this.postService.getPost(id);
 
     if (!post) {
@@ -39,7 +39,7 @@ Having the controller class implement `NestControllerInterface` ensures that you
 
 The `@Api` decorator takes the route, defines the path and method for the controller route.
 
-The `@TypedRequest` decorator takes the contract route defined in the `@Api` decorator, and returns the parsed and validated (if using Zod) request params, query and body.
+The `@TsRestRequest` decorator takes the contract route defined in the `@Api` decorator, and returns the parsed and validated (if using Zod) request params, query and body.
 
 As Typescript cannot infer class method parameter types from an implemented interface, we need to explicitly define the type for the request parameter using the `NestRequestShapes` type. 
 
@@ -63,7 +63,7 @@ export class PostController implements NestControllerInterface<typeof c> {
 
   @Api(s.route.getPost)
   @JsonQuery(false)
-  async getPost(@TypedRequest() { params: { id } }: RequestShapes['getPost']) {
+  async getPost(@TsRestRequest() { params: { id } }: RequestShapes['getPost']) {
     // ...
   }
 }
@@ -80,7 +80,7 @@ import {
   nestControllerContract,
   NestRequestShapes,
   NestResponseShapes,
-  TypedRequest,
+  TsRestRequest,
 } from '@ts-rest/nest';
 
 const c = nestControllerContract(apiBlog);
@@ -93,7 +93,7 @@ export class PostController {
 
   @Api(c.getPost)
   async getPost(
-    @TypedRequest() { params: { id } }: RequestShapes['getPost']
+    @TsRestRequest() { params: { id } }: RequestShapes['getPost']
   ): Promise<ResponseShapes['getPost']> {
     const post = await this.postService.getPost(id);
 

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -112,14 +112,14 @@ export class PostController implements NestControllerInterface<typeof c> {
   constructor(private readonly postService: PostService) {}
 
   @Api(c.getPost)
-  async getPost(@TypedRequest() { params: { id } }: RequestShapes['getPost']) {
+  async getPost(@TsRestRequest() { params: { id } }: RequestShapes['getPost']) {
     const post = await this.postService.getPost(id);
 
     return { status: 200 as const, body: post };
   }
 
   @Api(c.createPost)
-  async createPost(@TypedRequest() { body }: RequestShapes['createPost']) {
+  async createPost(@TsRestRequest() { body }: RequestShapes['createPost']) {
     const post = await this.postService.createPost({
       title: body.title,
       body: body.body,

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -104,23 +104,22 @@ normally Nest APIs are extremely powerful, but hard to make type safe.</p>
 ```typescript
 // post.controller.ts
 
-const s = initNestServer(contract);
-type ControllerShape = typeof s.controllerShape;
-type RouteShape = typeof s.routeShapes;
+const c = nestControllerContract(apiBlog);
+type RequestShapes = NestRequestShapes<typeof c>;
 
 @Controller()
-export class PostController implements ControllerShape {
+export class PostController implements NestControllerInterface<typeof c> {
   constructor(private readonly postService: PostService) {}
 
-  @Api(s.route.getPost)
-  async getPost(@ApiDecorator() { params: { id } }: RouteShape['getPost']) {
+  @Api(c.getPost)
+  async getPost(@TypedRequest() { params: { id } }: RequestShapes['getPost']) {
     const post = await this.postService.getPost(id);
 
     return { status: 200 as const, body: post };
   }
 
-  @Api(s.route.createPost)
-  async createPost(@ApiDecorator() { body }: RouteShape['createPost']) {
+  @Api(c.createPost)
+  async createPost(@TypedRequest() { body }: RequestShapes['createPost']) {
     const post = await this.postService.createPost({
       title: body.title,
       body: body.body,

--- a/apps/example-microservice/users-service/src/app/app.controller.ts
+++ b/apps/example-microservice/users-service/src/app/app.controller.ts
@@ -1,20 +1,25 @@
 import { Controller, UploadedFile, UseInterceptors } from '@nestjs/common';
 import { usersApi } from '@ts-rest/example-microservice/util-users-api';
-import { Api, ApiDecorator, initNestServer } from '@ts-rest/nest';
+import {
+  Api,
+  TypedRequest,
+  nestControllerContract,
+  NestControllerInterface,
+  NestRequestShapes,
+} from '@ts-rest/nest';
 import { AppService } from './app.service';
 import { FileInterceptor } from '@nestjs/platform-express';
 import 'multer';
 
-const s = initNestServer(usersApi);
-type ControllerShape = typeof s.controllerShape;
-type RouteShape = typeof s.routeShapes;
+const c = nestControllerContract(usersApi);
+type RequestShapes = NestRequestShapes<typeof c>;
 
 @Controller()
-export class AppController implements ControllerShape {
+export class AppController implements NestControllerInterface<typeof c> {
   constructor(private readonly appService: AppService) {}
 
-  @Api(s.route.getUser)
-  async getUser(@ApiDecorator() { params: { id } }: RouteShape['getUser']) {
+  @Api(c.getUser)
+  async getUser(@TypedRequest() { params: { id } }: RequestShapes['getUser']) {
     return {
       status: 200 as const,
       body: {
@@ -25,10 +30,10 @@ export class AppController implements ControllerShape {
     };
   }
 
-  @Api(s.route.updateUserAvatar)
+  @Api(c.updateUserAvatar)
   @UseInterceptors(FileInterceptor('avatar'))
   async updateUserAvatar(
-    @ApiDecorator() { params: { id } }: RouteShape['updateUserAvatar'],
+    @TypedRequest() { params: { id } }: RequestShapes['updateUserAvatar'],
     @UploadedFile() avatar: Express.Multer.File
   ) {
     return {

--- a/apps/example-microservice/users-service/src/app/app.controller.ts
+++ b/apps/example-microservice/users-service/src/app/app.controller.ts
@@ -2,7 +2,7 @@ import { Controller, UploadedFile, UseInterceptors } from '@nestjs/common';
 import { usersApi } from '@ts-rest/example-microservice/util-users-api';
 import {
   Api,
-  TypedRequest,
+  TsRestRequest,
   nestControllerContract,
   NestControllerInterface,
   NestRequestShapes,
@@ -19,7 +19,7 @@ export class AppController implements NestControllerInterface<typeof c> {
   constructor(private readonly appService: AppService) {}
 
   @Api(c.getUser)
-  async getUser(@TypedRequest() { params: { id } }: RequestShapes['getUser']) {
+  async getUser(@TsRestRequest() { params: { id } }: RequestShapes['getUser']) {
     return {
       status: 200 as const,
       body: {
@@ -33,7 +33,7 @@ export class AppController implements NestControllerInterface<typeof c> {
   @Api(c.updateUserAvatar)
   @UseInterceptors(FileInterceptor('avatar'))
   async updateUserAvatar(
-    @TypedRequest() { params: { id } }: RequestShapes['updateUserAvatar'],
+    @TsRestRequest() { params: { id } }: RequestShapes['updateUserAvatar'],
     @UploadedFile() avatar: Express.Multer.File
   ) {
     return {

--- a/apps/example-nest/src/app/post-json-query.controller.ts
+++ b/apps/example-nest/src/app/post-json-query.controller.ts
@@ -2,7 +2,7 @@ import { Controller } from '@nestjs/common';
 import { apiBlog } from '@ts-rest/example-contracts';
 import {
   Api,
-  TypedRequest,
+  TsRestRequest,
   JsonQuery,
   nestControllerContract,
   NestControllerInterface,
@@ -33,7 +33,8 @@ export class PostJsonQueryController
 
   @Api(c.getPosts)
   async getPosts(
-    @TypedRequest() { query: { take, skip, search } }: RequestShapes['getPosts']
+    @TsRestRequest()
+    { query: { take, skip, search } }: RequestShapes['getPosts']
   ) {
     const { posts, totalPosts } = await this.postService.getPosts({
       take,

--- a/apps/example-nest/src/app/post-json-query.controller.ts
+++ b/apps/example-nest/src/app/post-json-query.controller.ts
@@ -1,10 +1,17 @@
 import { Controller } from '@nestjs/common';
 import { apiBlog } from '@ts-rest/example-contracts';
-import { Api, ApiDecorator, initNestServer, JsonQuery } from '@ts-rest/nest';
+import {
+  Api,
+  TypedRequest,
+  JsonQuery,
+  nestControllerContract,
+  NestControllerInterface,
+  NestRequestShapes,
+} from '@ts-rest/nest';
 import { z } from 'zod';
 import { PostService } from './post.service';
 
-const s = initNestServer({
+const c = nestControllerContract({
   getPosts: {
     ...apiBlog.getPosts,
     path: '/posts-json-query',
@@ -15,17 +22,18 @@ const s = initNestServer({
     }),
   },
 });
-type ControllerShape = typeof s.controllerShape;
-type RouteShape = typeof s.routeShapes;
+type RequestShapes = NestRequestShapes<typeof c>;
 
 @JsonQuery()
 @Controller()
-export class PostJsonQueryController implements ControllerShape {
+export class PostJsonQueryController
+  implements NestControllerInterface<typeof c>
+{
   constructor(private readonly postService: PostService) {}
 
-  @Api(s.route.getPosts)
+  @Api(c.getPosts)
   async getPosts(
-    @ApiDecorator() { query: { take, skip, search } }: RouteShape['getPosts']
+    @TypedRequest() { query: { take, skip, search } }: RequestShapes['getPosts']
   ) {
     const { posts, totalPosts } = await this.postService.getPosts({
       take,

--- a/apps/example-nest/src/app/post.controller.ts
+++ b/apps/example-nest/src/app/post.controller.ts
@@ -1,15 +1,20 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { apiBlog } from '@ts-rest/example-contracts';
-import { Api, ApiDecorator, initNestServer } from '@ts-rest/nest';
+import {
+  Api,
+  nestControllerContract,
+  NestControllerInterface,
+  NestRequestShapes,
+  TypedRequest,
+} from '@ts-rest/nest';
 import { PostService } from './post.service';
 
-const s = initNestServer(apiBlog);
-type ControllerShape = typeof s.controllerShape;
-type RouteShape = typeof s.routeShapes;
+const c = nestControllerContract(apiBlog);
+type RequestShapes = NestRequestShapes<typeof c>;
 
-// You can implement the ControllerShape interface to ensure type safety
+// You can implement the NestControllerInterface interface to ensure type safety
 @Controller()
-export class PostController implements ControllerShape {
+export class PostController implements NestControllerInterface<typeof c> {
   constructor(private readonly postService: PostService) {}
 
   @Get('/test')
@@ -17,9 +22,9 @@ export class PostController implements ControllerShape {
     return { queryParams };
   }
 
-  @Api(s.route.getPosts)
+  @Api(c.getPosts)
   async getPosts(
-    @ApiDecorator() { query: { take, skip, search } }: RouteShape['getPosts']
+    @TypedRequest() { query: { take, skip, search } }: RequestShapes['getPosts']
   ) {
     const { posts, totalPosts } = await this.postService.getPosts({
       take,
@@ -33,8 +38,8 @@ export class PostController implements ControllerShape {
     };
   }
 
-  @Api(s.route.getPost)
-  async getPost(@ApiDecorator() { params: { id } }: RouteShape['getPost']) {
+  @Api(c.getPost)
+  async getPost(@TypedRequest() { params: { id } }: RequestShapes['getPost']) {
     const post = await this.postService.getPost(id);
 
     if (!post) {
@@ -44,8 +49,8 @@ export class PostController implements ControllerShape {
     return { status: 200 as const, body: post };
   }
 
-  @Api(s.route.createPost)
-  async createPost(@ApiDecorator() { body }: RouteShape['createPost']) {
+  @Api(c.createPost)
+  async createPost(@TypedRequest() { body }: RequestShapes['createPost']) {
     const post = await this.postService.createPost({
       title: body.title,
       content: body.content,
@@ -56,9 +61,9 @@ export class PostController implements ControllerShape {
     return { status: 201 as const, body: post };
   }
 
-  @Api(s.route.updatePost)
+  @Api(c.updatePost)
   async updatePost(
-    @ApiDecorator() { params: { id }, body }: RouteShape['updatePost']
+    @TypedRequest() { params: { id }, body }: RequestShapes['updatePost']
   ) {
     const post = await this.postService.updatePost(id, {
       title: body.title,
@@ -70,18 +75,18 @@ export class PostController implements ControllerShape {
     return { status: 200 as const, body: post };
   }
 
-  @Api(s.route.deletePost)
+  @Api(c.deletePost)
   async deletePost(
-    @ApiDecorator() { params: { id } }: RouteShape['deletePost']
+    @TypedRequest() { params: { id } }: RequestShapes['deletePost']
   ) {
     await this.postService.deletePost(id);
 
     return { status: 200 as const, body: { message: 'Post Deleted' } };
   }
 
-  @Api(s.route.testPathParams)
+  @Api(c.testPathParams)
   async testPathParams(
-    @ApiDecorator() { params }: RouteShape['testPathParams']
+    @TypedRequest() { params }: RequestShapes['testPathParams']
   ) {
     return { status: 200 as const, body: params };
   }

--- a/apps/example-nest/src/app/post.controller.ts
+++ b/apps/example-nest/src/app/post.controller.ts
@@ -5,7 +5,7 @@ import {
   nestControllerContract,
   NestControllerInterface,
   NestRequestShapes,
-  TypedRequest,
+  TsRestRequest,
 } from '@ts-rest/nest';
 import { PostService } from './post.service';
 
@@ -24,7 +24,8 @@ export class PostController implements NestControllerInterface<typeof c> {
 
   @Api(c.getPosts)
   async getPosts(
-    @TypedRequest() { query: { take, skip, search } }: RequestShapes['getPosts']
+    @TsRestRequest()
+    { query: { take, skip, search } }: RequestShapes['getPosts']
   ) {
     const { posts, totalPosts } = await this.postService.getPosts({
       take,
@@ -39,7 +40,7 @@ export class PostController implements NestControllerInterface<typeof c> {
   }
 
   @Api(c.getPost)
-  async getPost(@TypedRequest() { params: { id } }: RequestShapes['getPost']) {
+  async getPost(@TsRestRequest() { params: { id } }: RequestShapes['getPost']) {
     const post = await this.postService.getPost(id);
 
     if (!post) {
@@ -50,7 +51,7 @@ export class PostController implements NestControllerInterface<typeof c> {
   }
 
   @Api(c.createPost)
-  async createPost(@TypedRequest() { body }: RequestShapes['createPost']) {
+  async createPost(@TsRestRequest() { body }: RequestShapes['createPost']) {
     const post = await this.postService.createPost({
       title: body.title,
       content: body.content,
@@ -63,7 +64,7 @@ export class PostController implements NestControllerInterface<typeof c> {
 
   @Api(c.updatePost)
   async updatePost(
-    @TypedRequest() { params: { id }, body }: RequestShapes['updatePost']
+    @TsRestRequest() { params: { id }, body }: RequestShapes['updatePost']
   ) {
     const post = await this.postService.updatePost(id, {
       title: body.title,
@@ -77,7 +78,7 @@ export class PostController implements NestControllerInterface<typeof c> {
 
   @Api(c.deletePost)
   async deletePost(
-    @TypedRequest() { params: { id } }: RequestShapes['deletePost']
+    @TsRestRequest() { params: { id } }: RequestShapes['deletePost']
   ) {
     await this.postService.deletePost(id);
 
@@ -86,7 +87,7 @@ export class PostController implements NestControllerInterface<typeof c> {
 
   @Api(c.testPathParams)
   async testPathParams(
-    @TypedRequest() { params }: RequestShapes['testPathParams']
+    @TsRestRequest() { params }: RequestShapes['testPathParams']
   ) {
     return { status: 200 as const, body: params };
   }

--- a/apps/example-nest/src/app/post.controller.withResponseShapes.ts
+++ b/apps/example-nest/src/app/post.controller.withResponseShapes.ts
@@ -5,7 +5,7 @@ import {
   nestControllerContract,
   NestRequestShapes,
   NestResponseShapes,
-  TypedRequest,
+  TsRestRequest,
 } from '@ts-rest/nest';
 import { PostService } from './post.service';
 
@@ -25,7 +25,8 @@ export class PostController {
 
   @Api(c.getPosts)
   async getPosts(
-    @TypedRequest() { query: { take, skip, search } }: RequestShapes['getPosts']
+    @TsRestRequest()
+    { query: { take, skip, search } }: RequestShapes['getPosts']
   ): Promise<ResponseShapes['getPosts']> {
     const { posts, totalPosts } = await this.postService.getPosts({
       take,
@@ -41,7 +42,7 @@ export class PostController {
 
   @Api(c.getPost)
   async getPost(
-    @TypedRequest() { params: { id } }: RequestShapes['getPost']
+    @TsRestRequest() { params: { id } }: RequestShapes['getPost']
   ): Promise<ResponseShapes['getPost']> {
     const post = await this.postService.getPost(id);
 
@@ -54,7 +55,7 @@ export class PostController {
 
   @Api(c.createPost)
   async createPost(
-    @TypedRequest() { body }: RequestShapes['createPost']
+    @TsRestRequest() { body }: RequestShapes['createPost']
   ): Promise<ResponseShapes['createPost']> {
     const post = await this.postService.createPost({
       title: body.title,
@@ -68,7 +69,7 @@ export class PostController {
 
   @Api(c.updatePost)
   async updatePost(
-    @TypedRequest() { params: { id }, body }: RequestShapes['updatePost']
+    @TsRestRequest() { params: { id }, body }: RequestShapes['updatePost']
   ): Promise<ResponseShapes['updatePost']> {
     const post = await this.postService.updatePost(id, {
       title: body.title,
@@ -82,7 +83,7 @@ export class PostController {
 
   @Api(c.deletePost)
   async deletePost(
-    @TypedRequest() { params: { id } }: RequestShapes['deletePost']
+    @TsRestRequest() { params: { id } }: RequestShapes['deletePost']
   ): Promise<ResponseShapes['deletePost']> {
     await this.postService.deletePost(id);
 
@@ -91,7 +92,7 @@ export class PostController {
 
   @Api(c.testPathParams)
   async testPathParams(
-    @TypedRequest() { params }: RequestShapes['testPathParams']
+    @TsRestRequest() { params }: RequestShapes['testPathParams']
   ): Promise<ResponseShapes['testPathParams']> {
     return { status: 200, body: params };
   }

--- a/apps/example-nest/src/app/post.controller.withResponseShapes.ts
+++ b/apps/example-nest/src/app/post.controller.withResponseShapes.ts
@@ -1,16 +1,21 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { apiBlog } from '@ts-rest/example-contracts';
-import { Api, ApiDecorator, initNestServer } from '@ts-rest/nest';
+import {
+  Api,
+  nestControllerContract,
+  NestRequestShapes,
+  NestResponseShapes,
+  TypedRequest,
+} from '@ts-rest/nest';
 import { PostService } from './post.service';
 
-const s = initNestServer(apiBlog);
-type RouteShape = typeof s.routeShapes;
-type ResponseShapes = typeof s.responseShapes;
+const c = nestControllerContract(apiBlog);
+type RequestShapes = NestRequestShapes<typeof c>;
+type ResponseShapes = NestResponseShapes<typeof c>;
 
 // Alternatively, you can the use the ResponseShapes type to ensure type safety
-
 @Controller()
-export class PostController  {
+export class PostController {
   constructor(private readonly postService: PostService) {}
 
   @Get('/test')
@@ -18,9 +23,9 @@ export class PostController  {
     return { queryParams };
   }
 
-  @Api(s.route.getPosts)
+  @Api(c.getPosts)
   async getPosts(
-    @ApiDecorator() { query: { take, skip, search } }: RouteShape['getPosts']
+    @TypedRequest() { query: { take, skip, search } }: RequestShapes['getPosts']
   ): Promise<ResponseShapes['getPosts']> {
     const { posts, totalPosts } = await this.postService.getPosts({
       take,
@@ -34,9 +39,10 @@ export class PostController  {
     };
   }
 
-  @Api(s.route.getPost)
-  async getPost(@ApiDecorator() { params: { id } }: RouteShape['getPost']):
-    Promise<ResponseShapes['getPost']> {
+  @Api(c.getPost)
+  async getPost(
+    @TypedRequest() { params: { id } }: RequestShapes['getPost']
+  ): Promise<ResponseShapes['getPost']> {
     const post = await this.postService.getPost(id);
 
     if (!post) {
@@ -46,9 +52,10 @@ export class PostController  {
     return { status: 200, body: post };
   }
 
-  @Api(s.route.createPost)
-  async createPost(@ApiDecorator() { body }: RouteShape['createPost']): 
-    Promise<ResponseShapes['createPost']> {
+  @Api(c.createPost)
+  async createPost(
+    @TypedRequest() { body }: RequestShapes['createPost']
+  ): Promise<ResponseShapes['createPost']> {
     const post = await this.postService.createPost({
       title: body.title,
       content: body.content,
@@ -59,9 +66,9 @@ export class PostController  {
     return { status: 201, body: post };
   }
 
-  @Api(s.route.updatePost)
+  @Api(c.updatePost)
   async updatePost(
-    @ApiDecorator() { params: { id }, body }: RouteShape['updatePost']
+    @TypedRequest() { params: { id }, body }: RequestShapes['updatePost']
   ): Promise<ResponseShapes['updatePost']> {
     const post = await this.postService.updatePost(id, {
       title: body.title,
@@ -73,18 +80,18 @@ export class PostController  {
     return { status: 200, body: post };
   }
 
-  @Api(s.route.deletePost)
+  @Api(c.deletePost)
   async deletePost(
-    @ApiDecorator() { params: { id } }: RouteShape['deletePost']
+    @TypedRequest() { params: { id } }: RequestShapes['deletePost']
   ): Promise<ResponseShapes['deletePost']> {
     await this.postService.deletePost(id);
 
     return { status: 200, body: { message: 'Post Deleted' } };
   }
 
-  @Api(s.route.testPathParams)
+  @Api(c.testPathParams)
   async testPathParams(
-    @ApiDecorator() { params }: RouteShape['testPathParams']
+    @TypedRequest() { params }: RequestShapes['testPathParams']
   ): Promise<ResponseShapes['testPathParams']> {
     return { status: 200, body: params };
   }

--- a/libs/ts-rest/core/src/lib/zod-utils.ts
+++ b/libs/ts-rest/core/src/lib/zod-utils.ts
@@ -34,7 +34,10 @@ export const checkZodSchema = (
 
     return {
       success: false,
-      error: result.error,
+      error: {
+        name: result.error.name,
+        issues: result.error.issues,
+      },
     };
   }
 

--- a/libs/ts-rest/nest/src/index.ts
+++ b/libs/ts-rest/nest/src/index.ts
@@ -1,4 +1,4 @@
 export * from './lib/json-query.decorator';
 export * from './lib/ts-rest-nest';
 export * from './lib/ts-rest.interceptor';
-export * from './lib/typed-request.decorator';
+export * from './lib/ts-rest-request.decorator';

--- a/libs/ts-rest/nest/src/index.ts
+++ b/libs/ts-rest/nest/src/index.ts
@@ -1,3 +1,4 @@
-export * from './lib/ts-rest-nest';
-export * from './lib/api.decorator';
 export * from './lib/json-query.decorator';
+export * from './lib/ts-rest-nest';
+export * from './lib/ts-rest.interceptor';
+export * from './lib/typed-request.decorator';

--- a/libs/ts-rest/nest/src/lib/json-query.decorator.ts
+++ b/libs/ts-rest/nest/src/lib/json-query.decorator.ts
@@ -1,5 +1,8 @@
 export const JsonQuerySymbol = Symbol('JsonQuery');
 
+/**
+ * Enable JSON query mode for a controller or a single route
+ */
 export const JsonQuery = (
   jsonQuery = true
 ): ClassDecorator & MethodDecorator => {

--- a/libs/ts-rest/nest/src/lib/ts-rest-nest.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest-nest.ts
@@ -65,6 +65,9 @@ export type NestRequestShapes<T extends AppRouter> = NestAppRouteShape<T>;
 export type NestResponseShapes<T extends AppRouter> =
   AppRouterResponseShapes<T>;
 
+/**
+ * Returns the contract containing only non-nested routes required by a NestJS controller
+ */
 export const nestControllerContract = <T extends AppRouter>(router: T) => {
   // it's not worth actually filtering the contract at runtime
   // the typing will already ensure that nested routes cannot be used at compile time

--- a/libs/ts-rest/nest/src/lib/ts-rest-nest.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest-nest.ts
@@ -41,7 +41,8 @@ type NestControllerShapeFromAppRouter<T extends AppRouter> = Without<
 type NestAppRouteShape<T extends AppRouter> = AppRouterRequestShapes<T>;
 
 /**
- * @deprecated Use `nestControllerContract`, `NestControllerInterface`, `NestRequestShapes`, and `NestResponseShapes` instead. Check the docs for more info.
+ * @deprecated Use `nestControllerContract`, `NestControllerInterface`, `NestRequestShapes`, and `NestResponseShapes` instead
+ * @see {@link https://ts-rest.com/docs/nest|ts-rest docs} for more info.
  */
 export const initNestServer = <T extends AppRouter>(router: T) => {
   return {

--- a/libs/ts-rest/nest/src/lib/ts-rest-nest.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest-nest.ts
@@ -6,7 +6,7 @@ import {
   getRouteResponses,
   ApiResponseForRoute,
 } from '@ts-rest/core';
-import { TypedRequestShape } from './typed-request.decorator';
+import { TsRestRequestShape } from './ts-rest-request.decorator';
 
 type AppRouterMethodShape<T extends AppRoute> = (
   ...args: any[]
@@ -21,7 +21,7 @@ type AppRouterControllerShape<T extends AppRouter> = Without<
 
 type AppRouterRequestShapes<T extends AppRouter> = Without<
   {
-    [K in keyof T]: T[K] extends AppRoute ? TypedRequestShape<T[K]> : never;
+    [K in keyof T]: T[K] extends AppRoute ? TsRestRequestShape<T[K]> : never;
   },
   never
 >;

--- a/libs/ts-rest/nest/src/lib/ts-rest-nest.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest-nest.ts
@@ -1,33 +1,48 @@
-import { AppRoute, AppRouter, ApiRouteResponse, Without, getRouteResponses } from '@ts-rest/core';
-import { ApiDecoratorShape } from './api.decorator';
+import {
+  AppRoute,
+  AppRouter,
+  ApiRouteResponse,
+  Without,
+  getRouteResponses,
+  ApiResponseForRoute,
+} from '@ts-rest/core';
+import { TypedRequestShape } from './typed-request.decorator';
 
 type AppRouterMethodShape<T extends AppRoute> = (
   ...args: any[]
 ) => Promise<ApiRouteResponse<T['responses']>>;
 
-type AppRouterControllerShape<T extends AppRouter> = {
-  [K in keyof T]: T[K] extends AppRouter
-    ? undefined
-    : T[K] extends AppRoute
-    ? AppRouterMethodShape<T[K]>
-    : never;
-};
+type AppRouterControllerShape<T extends AppRouter> = Without<
+  {
+    [K in keyof T]: T[K] extends AppRoute ? AppRouterMethodShape<T[K]> : never;
+  },
+  never
+>;
 
-type AppRouteShape<T extends AppRouter> = {
-  [K in keyof T]: T[K] extends AppRouter
-    ? AppRouteShape<T[K]>
-    : T[K] extends AppRoute
-    ? ApiDecoratorShape<T[K]>
-    : never;
-};
+type AppRouterRequestShapes<T extends AppRouter> = Without<
+  {
+    [K in keyof T]: T[K] extends AppRoute ? TypedRequestShape<T[K]> : never;
+  },
+  never
+>;
 
-export type NestControllerShapeFromAppRouter<T extends AppRouter> = Without<
+type AppRouterResponseShapes<T extends AppRouter> = Without<
+  {
+    [K in keyof T]: T[K] extends AppRoute ? ApiResponseForRoute<T[K]> : never;
+  },
+  never
+>;
+
+type NestControllerShapeFromAppRouter<T extends AppRouter> = Without<
   AppRouterControllerShape<T>,
   AppRouter
 >;
 
-export type NestAppRouteShape<T extends AppRouter> = AppRouteShape<T>;
+type NestAppRouteShape<T extends AppRouter> = AppRouterRequestShapes<T>;
 
+/**
+ * @deprecated Use `nestControllerContract`, `NestControllerInterface`, `NestRequestShapes`, and `NestResponseShapes` instead. Check the docs for more info.
+ */
 export const initNestServer = <T extends AppRouter>(router: T) => {
   return {
     controllerShape: {} as NestControllerShapeFromAppRouter<T>,
@@ -35,4 +50,22 @@ export const initNestServer = <T extends AppRouter>(router: T) => {
     responseShapes: getRouteResponses(router),
     route: router,
   };
+};
+
+export type NestControllerContract<T extends AppRouter> = Pick<
+  T,
+  {
+    [K in keyof T]-?: T[K] extends AppRoute ? K : never;
+  }[keyof T]
+>;
+export type NestControllerInterface<T extends AppRouter> =
+  AppRouterControllerShape<T>;
+export type NestRequestShapes<T extends AppRouter> = NestAppRouteShape<T>;
+export type NestResponseShapes<T extends AppRouter> =
+  AppRouterResponseShapes<T>;
+
+export const nestControllerContract = <T extends AppRouter>(router: T) => {
+  // it's not worth actually filtering the contract at runtime
+  // the typing will already ensure that nested routes cannot be used at compile time
+  return router as NestControllerContract<T>;
 };

--- a/libs/ts-rest/nest/src/lib/ts-rest-request.decorator.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest-request.decorator.ts
@@ -22,7 +22,7 @@ type BodyWithoutFileIfMultiPart<T extends AppRouteMutation> =
     ? Without<ZodInferOrType<T['body']>, File>
     : ZodInferOrType<T['body']>;
 
-export type TypedRequestShape<TRoute extends AppRoute> = Without<
+export type TsRestRequestShape<TRoute extends AppRoute> = Without<
   {
     params: PathParamsWithCustomValidators<TRoute>;
     body: TRoute extends AppRouteMutation
@@ -33,8 +33,8 @@ export type TypedRequestShape<TRoute extends AppRoute> = Without<
   never
 >;
 
-export const TypedRequest = createParamDecorator(
-  (_: unknown, ctx: ExecutionContext): TypedRequestShape<any> => {
+export const TsRestRequest = createParamDecorator(
+  (_: unknown, ctx: ExecutionContext): TsRestRequestShape<any> => {
     const req: Request = ctx.switchToHttp().getRequest();
     const appRoute: AppRoute | undefined = Reflect.getMetadata(
       tsRestAppRouteMetadataKey,
@@ -87,6 +87,6 @@ export const TypedRequest = createParamDecorator(
 );
 
 /**
- * @deprecated Use `TypedRequest` instead
+ * @deprecated Use `TsRestRequest` instead
  */
-export const ApiDecorator = TypedRequest;
+export const ApiDecorator = TsRestRequest;

--- a/libs/ts-rest/nest/src/lib/ts-rest-request.decorator.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest-request.decorator.ts
@@ -33,6 +33,9 @@ export type TsRestRequestShape<TRoute extends AppRoute> = Without<
   never
 >;
 
+/**
+ * Parameter decorator used to parse, validate and return the typed request object
+ */
 export const TsRestRequest = createParamDecorator(
   (_: unknown, ctx: ExecutionContext): TsRestRequestShape<any> => {
     const req: Request = ctx.switchToHttp().getRequest();

--- a/libs/ts-rest/nest/src/lib/ts-rest.interceptor.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest.interceptor.ts
@@ -15,7 +15,7 @@ import {
 import { map, Observable } from 'rxjs';
 import { Response } from 'express-serve-static-core';
 import { AppRoute } from '@ts-rest/core';
-import { tsRestAppRouteMetadataKey } from './typed-request.decorator';
+import { tsRestAppRouteMetadataKey } from './ts-rest-request.decorator';
 
 @Injectable()
 export class TsRestInterceptor implements NestInterceptor {

--- a/libs/ts-rest/nest/src/lib/ts-rest.interceptor.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest.interceptor.ts
@@ -54,6 +54,10 @@ const getMethodDecorator = (appRoute: AppRoute) => {
   }
 };
 
+/**
+ * Method decorator used to register a route's path and method from the passed route and handle ts-rest response objects
+ * @param appRoute The route to register
+ */
 export const Api = (appRoute: AppRoute): MethodDecorator => {
   const methodDecorator = getMethodDecorator(appRoute);
 

--- a/libs/ts-rest/nest/src/lib/ts-rest.interceptor.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest.interceptor.ts
@@ -1,0 +1,65 @@
+import {
+  applyDecorators,
+  CallHandler,
+  Delete,
+  ExecutionContext,
+  Get,
+  Injectable,
+  NestInterceptor,
+  Patch,
+  Post,
+  Put,
+  SetMetadata,
+  UseInterceptors,
+} from '@nestjs/common';
+import { map, Observable } from 'rxjs';
+import { Response } from 'express-serve-static-core';
+import { AppRoute } from '@ts-rest/core';
+import { tsRestAppRouteMetadataKey } from './typed-request.decorator';
+
+@Injectable()
+export class TsRestInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const res: Response = context.switchToHttp().getResponse();
+
+    return next.handle().pipe(
+      map((value) => {
+        if (
+          typeof value === 'object' &&
+          typeof value.status === 'number' &&
+          value.body !== undefined
+        ) {
+          res.status(value.status);
+          return value.body;
+        }
+
+        return value;
+      })
+    );
+  }
+}
+
+const getMethodDecorator = (appRoute: AppRoute) => {
+  switch (appRoute.method) {
+    case 'DELETE':
+      return Delete(appRoute.path);
+    case 'GET':
+      return Get(appRoute.path);
+    case 'POST':
+      return Post(appRoute.path);
+    case 'PATCH':
+      return Patch(appRoute.path);
+    case 'PUT':
+      return Put(appRoute.path);
+  }
+};
+
+export const Api = (appRoute: AppRoute): MethodDecorator => {
+  const methodDecorator = getMethodDecorator(appRoute);
+
+  return applyDecorators(
+    SetMetadata(tsRestAppRouteMetadataKey, appRoute),
+    methodDecorator,
+    UseInterceptors(TsRestInterceptor)
+  );
+};

--- a/libs/ts-rest/nest/src/lib/typed-request.decorator.ts
+++ b/libs/ts-rest/nest/src/lib/typed-request.decorator.ts
@@ -47,7 +47,7 @@ export const TypedRequest = createParamDecorator(
     }
 
     const isJsonQuery = !!(
-      Reflect.getMetadata(JsonQuerySymbol, ctx.getHandler()) ||
+      Reflect.getMetadata(JsonQuerySymbol, ctx.getHandler()) ??
       Reflect.getMetadata(JsonQuerySymbol, ctx.getClass())
     );
 

--- a/libs/ts-rest/nest/src/lib/typed-request.decorator.ts
+++ b/libs/ts-rest/nest/src/lib/typed-request.decorator.ts
@@ -1,18 +1,7 @@
 import {
-  applyDecorators,
   BadRequestException,
-  CallHandler,
   createParamDecorator,
-  Delete,
   ExecutionContext,
-  Get,
-  Injectable,
-  NestInterceptor,
-  Patch,
-  Post,
-  Put,
-  SetMetadata,
-  UseInterceptors,
 } from '@nestjs/common';
 import {
   AppRoute,
@@ -23,18 +12,17 @@ import {
   Without,
   ZodInferOrType,
 } from '@ts-rest/core';
-import { map, Observable } from 'rxjs';
-import type { Request, Response } from 'express-serve-static-core';
+import type { Request } from 'express-serve-static-core';
 import { JsonQuerySymbol } from './json-query.decorator';
 
-const tsRestAppRouteMetadataKey = Symbol('ts-rest-app-route');
+export const tsRestAppRouteMetadataKey = Symbol('ts-rest-app-route');
 
 type BodyWithoutFileIfMultiPart<T extends AppRouteMutation> =
   T['contentType'] extends 'multipart/form-data'
     ? Without<ZodInferOrType<T['body']>, File>
     : ZodInferOrType<T['body']>;
 
-export type ApiDecoratorShape<TRoute extends AppRoute> = Without<
+export type TypedRequestShape<TRoute extends AppRoute> = Without<
   {
     params: PathParamsWithCustomValidators<TRoute>;
     body: TRoute extends AppRouteMutation
@@ -45,8 +33,8 @@ export type ApiDecoratorShape<TRoute extends AppRoute> = Without<
   never
 >;
 
-export const ApiDecorator = createParamDecorator(
-  (_: unknown, ctx: ExecutionContext): ApiDecoratorShape<any> => {
+export const TypedRequest = createParamDecorator(
+  (_: unknown, ctx: ExecutionContext): TypedRequestShape<any> => {
     const req: Request = ctx.switchToHttp().getRequest();
     const appRoute: AppRoute | undefined = Reflect.getMetadata(
       tsRestAppRouteMetadataKey,
@@ -98,49 +86,7 @@ export const ApiDecorator = createParamDecorator(
   }
 );
 
-const getMethodDecorator = (appRoute: AppRoute) => {
-  switch (appRoute.method) {
-    case 'DELETE':
-      return Delete(appRoute.path);
-    case 'GET':
-      return Get(appRoute.path);
-    case 'POST':
-      return Post(appRoute.path);
-    case 'PATCH':
-      return Patch(appRoute.path);
-    case 'PUT':
-      return Put(appRoute.path);
-  }
-};
-
-@Injectable()
-export class ApiRouteInterceptor implements NestInterceptor {
-  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
-    const res: Response = context.switchToHttp().getResponse();
-
-    return next.handle().pipe(
-      map((value) => {
-        if (
-          typeof value === 'object' &&
-          typeof value.status === 'number' &&
-          value.body !== undefined
-        ) {
-          res.status(value.status);
-          return value.body;
-        }
-
-        return value;
-      })
-    );
-  }
-}
-
-export const Api = (appRoute: AppRoute): MethodDecorator => {
-  const methodDecorator = getMethodDecorator(appRoute);
-
-  return applyDecorators(
-    SetMetadata(tsRestAppRouteMetadataKey, appRoute),
-    methodDecorator,
-    UseInterceptors(ApiRouteInterceptor)
-  );
-};
+/**
+ * @deprecated Use `TypedRequest` instead
+ */
+export const ApiDecorator = TypedRequest;


### PR DESCRIPTION
I've renamed some of the Nest function and type names as they have confused some people.

I've also changed how the types are consumed rather than using the `{} as T` hack. In my opinion, this makes it clearer that we are providing types rather than running any significant code at runtime.

Also updated the docs to better explain the role of every function and decorator, and how the type safety is done.
 
Also fixes #122 