### PR TITLE
fix: clone the response body before reading json

### DIFF
--- a/apps/example-next/tests/react-query.spec.tsx
+++ b/apps/example-next/tests/react-query.spec.tsx
@@ -182,6 +182,38 @@ describe('react-query', () => {
     expect(result.current.data).toStrictEqual(SUCCESS_RESPONSE);
   });
 
+  it('useQuery should accept non-json string response', () => {
+    api.mockResolvedValue({
+      status: 200,
+      body: 'Hello World',
+    });
+
+    const { result } = renderHook(() => client.health.useQuery(['health']), {
+      wrapper,
+    });
+
+    expect(result.current.data).toStrictEqual(undefined);
+
+    expect(result.current.isLoading).toStrictEqual(true);
+
+    expect(api).toHaveBeenCalledWith({
+      method: 'GET',
+      path: 'http://api.com/health',
+      body: undefined,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    return waitFor(() => {
+      expect(result.current.isLoading).toStrictEqual(false);
+      expect(result.current.data).toStrictEqual({
+        status: 200,
+        body: 'Hello World',
+      });
+    });
+  });
+
   it('useQuery should handle failure', async () => {
     api.mockResolvedValue(ERROR_RESPONSE);
 

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -293,6 +293,23 @@ describe('client', () => {
         body: undefined,
       });
     });
+
+    it('w/ a non json response (string)', async () => {
+      api.mockResolvedValue({ body: 'string', status: 200 });
+
+      const result = await client.posts.getPosts({});
+
+      expect(result).toStrictEqual({ body: 'string', status: 200 });
+
+      expect(api).toHaveBeenCalledWith({
+        method: 'GET',
+        path: 'https://api.com/posts',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: undefined,
+      });
+    });
   });
 
   describe('post', () => {

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -114,7 +114,7 @@ export const defaultApi: ApiFetcher = async ({
   try {
     return {
       status: result.status,
-      body: await result.json(),
+      body: await result.clone().json(),
     };
   } catch {
     return {


### PR DESCRIPTION
Fixes #141 

@Gabrola @michaelangrivera I think this fixes the issue, cloning the body before we try to convert it to json.