### PR TITLE
Fix incorrect @ts-react/react-query package name in docs

### DIFF
--- a/apps/docs/docs/react-query.md
+++ b/apps/docs/docs/react-query.md
@@ -1,6 +1,6 @@
 # React Query
 
-This is a client using` @ts-react/react-query`, using `@tanstack/react-query` under the hood.
+This is a client using` @ts-rest/react-query`, using `@tanstack/react-query` under the hood.
 
 ## initQueryClient
 
@@ -86,7 +86,7 @@ The reason for this is error handling! Please see the [Relevant Docs](/docs/core
 
 ## Regular Query and Mutations
 
-`@ts-rest/react-query` allows for a regular fetch or mutation if you want, without having to initialise two different clients, one with `@ts-rest/core` and one with `@ts-react/react-query`.
+`@ts-rest/react-query` allows for a regular fetch or mutation if you want, without having to initialise two different clients, one with `@ts-rest/core` and one with `@ts-rest/react-query`.
 
 ```typescript
 // Normal fetch

--- a/apps/docs/docs/react-query.md
+++ b/apps/docs/docs/react-query.md
@@ -1,6 +1,6 @@
 # React Query
 
-This is a client using` @ts-rest/react-query`, using `@tanstack/react-query` under the hood.
+This is a client using `@ts-rest/react-query`, using `@tanstack/react-query` under the hood.
 
 ## initQueryClient
 


### PR DESCRIPTION
Hi, thanks for the awesome library!

I just tried it out with next.js as a backend implementation. While I was reading the doc, I found that there is a wrong package name in the documentation. I realized it when I try to install it and it is not found. Turns out the right package name was the one in the sidebar. So, I want to contribute a little to fix the doc.

Thanks