### PR TITLE
refactor: type safe TsRest decorator

### DIFF
--- a/.changeset/fresh-dodos-try.md
+++ b/.changeset/fresh-dodos-try.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/nest': patch
+---
+
+Increased type safety for the @TsRest decorator

--- a/libs/ts-rest/nest/src/lib/ts-rest.decorator.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest.decorator.ts
@@ -21,12 +21,17 @@ export type TsRestOptions = {
   validateResponses?: boolean;
 };
 
+type TsRestType = {
+  (appRoute: AppRoute, options?: TsRestOptions): MethodDecorator;
+  (options: TsRestOptions): ClassDecorator;
+};
+
 /**
  * As a class decorator, you can configure ts-rest options. As a method decorator, you can assign the route and also configure options
  * @param appRouteOrOptions For a method decorator, this is the route. For a class decorator, this is the options
  * @param options For a method decorator, this is the options
  */
-export const TsRest = (
+export const TsRest: TsRestType = (
   appRouteOrOptions: AppRoute | TsRestOptions,
   options: TsRestOptions = {}
 ) => {


### PR DESCRIPTION
Pretty neat little method to do "overloads" for arrow functions. This prevents the method decorator signature from being used on classes and vice-versa.

![Screenshot 2023-02-02 172708](https://user-images.githubusercontent.com/1728215/216371847-caf24a08-ec32-4daa-8107-3cabe408428d.png)
