### PR TITLE
fix: do not throw error for missing content-type header

### DIFF
--- a/.changeset/nine-wasps-flash.md
+++ b/.changeset/nine-wasps-flash.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': patch
+---
+
+Do not throw error for missing content-type header

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -108,15 +108,11 @@ export const defaultApi: ApiFetcher = async ({
   const result = await fetch(path, { method, headers, body, credentials });
   const contentType = result.headers.get('content-type');
 
-  if (!contentType) {
-    throw TypeError('Resource Response missing content-type header');
-  }
-
-  if (contentType.includes('application/json')) {
+  if (contentType?.includes('application/json')) {
     return { status: result.status, body: await result.json() };
   }
 
-  if (contentType.includes('text/plain')) {
+  if (contentType?.includes('text/plain')) {
     return { status: result.status, body: await result.text() };
   }
 

--- a/libs/ts-rest/express/src/lib/ts-rest-express.ts
+++ b/libs/ts-rest/express/src/lib/ts-rest-express.ts
@@ -243,7 +243,7 @@ const transformAppRouteMutationImplementation = (
 
       return res.status(statusCode).json(result.body);
     } catch (e) {
-      return next?.(e);
+      return next(e);
     }
   };
 


### PR DESCRIPTION
According to [RFC 2616](https://www.rfc-editor.org/rfc/rfc2616#section-7.2.1) a response _SHOULD_, but not _MUST_, include a content-type header. There are cases where a content-type header is not required such as when returning an empty response. This is common for some DELETE endpoints that return a `204 No Content` response.

I think in this case, returning a blob is appropriate and let the developers handle it how they please