### PR TITLE
feat: better OpenAPI generation and include zod pathParams

### DIFF
--- a/.changeset/hot-ways-flow.md
+++ b/.changeset/hot-ways-flow.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/open-api': minor
+---
+
+Improved OpenAPI generation

--- a/libs/ts-rest/open-api/package.json
+++ b/libs/ts-rest/open-api/package.json
@@ -2,16 +2,11 @@
   "name": "@ts-rest/open-api",
   "version": "3.16.2",
   "dependencies": {
-    "openapi3-ts": "^2.0.2",
-    "zod-to-json-schema": "^3.17.1"
+    "@anatine/zod-openapi": "^1.12.0",
+    "openapi3-ts": "^2.0.2"
   },
   "peerDependencies": {
     "zod": "^3.0.0"
-  },
-  "peerDependenciesMeta": {
-    "zod": {
-      "optional": true
-    }
   },
   "typedoc": {
     "entryPoint": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "dependencies": {
     "@actions/core": "^1.10.0",
+    "@anatine/zod-openapi": "^1.12.0",
     "@babel/runtime": "^7.20.6",
     "@changesets/cli": "^2.24.3",
     "@docusaurus/core": "2.0.1",
@@ -102,7 +103,6 @@
     "uuid": "^8.3.2",
     "vitest": "^0.23.4",
     "zod": "^3.18.0",
-    "zod-to-json-schema": "^3.17.1",
     "zustand": "^4.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ importers:
   .:
     specifiers:
       '@actions/core': ^1.10.0
+      '@anatine/zod-openapi': ^1.12.0
       '@babel/preset-react': ^7.14.5
       '@babel/runtime': ^7.20.6
       '@changesets/cli': ^2.24.3
@@ -174,10 +175,10 @@ importers:
       webpack: ^5.75.0
       webpack-merge: ^5.8.0
       zod: ^3.18.0
-      zod-to-json-schema: ^3.17.1
       zustand: ^4.1.1
     dependencies:
       '@actions/core': 1.10.0
+      '@anatine/zod-openapi': 1.12.0_jaqnetbcjcsissttd5r7v75rg4
       '@babel/runtime': 7.20.6
       '@changesets/cli': 2.24.4
       '@docusaurus/core': 2.0.1_jcfe4ra3qxngmagfuvsim2yzgq
@@ -257,7 +258,6 @@ importers:
       uuid: 8.3.2
       vitest: 0.23.4_sass@1.55.0+stylus@0.55.0
       zod: 3.19.1
-      zod-to-json-schema: 3.17.1_zod@3.19.1
       zustand: 4.1.1_react@18.2.0
     devDependencies:
       '@babel/preset-react': 7.18.6
@@ -392,11 +392,11 @@ importers:
 
   libs/ts-rest/open-api:
     specifiers:
+      '@anatine/zod-openapi': ^1.12.0
       openapi3-ts: ^2.0.2
-      zod-to-json-schema: ^3.17.1
     dependencies:
+      '@anatine/zod-openapi': 1.12.0_openapi3-ts@2.0.2
       openapi3-ts: 2.0.2
-      zod-to-json-schema: 3.17.1
 
   libs/ts-rest/react-query:
     specifiers: {}
@@ -543,6 +543,27 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.15
+
+  /@anatine/zod-openapi/1.12.0_jaqnetbcjcsissttd5r7v75rg4:
+    resolution: {integrity: sha512-ZdkmQFXdc2us0nTBPWiJ3joHxsZoc5G79hKB8QzUuo73zp2A4t4TlBmOjS+hJfMnTBATfJutrlN/wK4DUq6ztg==}
+    peerDependencies:
+      openapi3-ts: ^2.0.0 || ^3.0.0
+      zod: ^3.20.0
+    dependencies:
+      openapi3-ts: 2.0.2
+      ts-deepmerge: 4.0.0
+      zod: 3.19.1
+    dev: false
+
+  /@anatine/zod-openapi/1.12.0_openapi3-ts@2.0.2:
+    resolution: {integrity: sha512-ZdkmQFXdc2us0nTBPWiJ3joHxsZoc5G79hKB8QzUuo73zp2A4t4TlBmOjS+hJfMnTBATfJutrlN/wK4DUq6ztg==}
+    peerDependencies:
+      openapi3-ts: ^2.0.0 || ^3.0.0
+      zod: ^3.20.0
+    dependencies:
+      openapi3-ts: 2.0.2
+      ts-deepmerge: 4.0.0
+    dev: false
 
   /@angular-devkit/core/14.2.1:
     resolution: {integrity: sha512-lW8oNGuJqr4r31FWBjfWQYkSXdiOHBGOThIEtHvUVBKfPF/oVrupLueCUgBPel+NvxENXdo93uPsqHN7bZbmsQ==}
@@ -25978,6 +25999,11 @@ packages:
       utf8-byte-length: 1.0.4
     dev: true
 
+  /ts-deepmerge/4.0.0:
+    resolution: {integrity: sha512-IrjjAwfM/J6ajWv5wDRZBdpVaTmuONJN1vC85mXlWVPXKelouLFiqsjR7m0h245qY6zZEtcDtcOTc4Rozgg1TQ==}
+    engines: {node: '>=14'}
+    dev: false
+
   /ts-interface-checker/0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -27831,20 +27857,6 @@ packages:
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  /zod-to-json-schema/3.17.1:
-    resolution: {integrity: sha512-h1WLfvkdwM6lcRt5q09ytNh2OKcU13vY9D0FetN/7Erdd7lVraIiMkEnObg3KELm5EQlMqvi0r5nzMa0EA+8qw==}
-    peerDependencies:
-      zod: ^3.17.10
-    dev: false
-
-  /zod-to-json-schema/3.17.1_zod@3.19.1:
-    resolution: {integrity: sha512-h1WLfvkdwM6lcRt5q09ytNh2OKcU13vY9D0FetN/7Erdd7lVraIiMkEnObg3KELm5EQlMqvi0r5nzMa0EA+8qw==}
-    peerDependencies:
-      zod: ^3.17.10
-    dependencies:
-      zod: 3.19.1
-    dev: false
 
   /zod/3.19.1:
     resolution: {integrity: sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==}


### PR DESCRIPTION
Path params were included from the path itself only and not taking into account any extra zod typings provided through `pathParams`, so I've added that.

Nullish fields were also being generated as an incorrect

```javascript
{
  anyOf: [
    {
      not: {},
    },
    {
      type: 'string',
    },
  ],
}
```

The zod-openapi package fixes that

