### PR TITLE
Allow extra API client args, allow headers, and prettify query args

### DIFF
--- a/.changeset/calm-bananas-guess.md
+++ b/.changeset/calm-bananas-guess.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/react-query': minor
+---
+
+Allow custom API to allow extra args, type them in the react query api calls

--- a/.changeset/clean-dots-relate.md
+++ b/.changeset/clean-dots-relate.md
@@ -1,0 +1,6 @@
+---
+'@ts-rest/core': minor
+'@ts-rest/solid-query': minor
+---
+
+Export the default fetch API as `tsRestFetchApi` from the core library, enables you to easy modify the fetcher

--- a/.changeset/early-pillows-train.md
+++ b/.changeset/early-pillows-train.md
@@ -1,0 +1,7 @@
+---
+'@ts-rest/core': minor
+'@ts-rest/react-query': minor
+'@ts-rest/solid-query': minor
+---
+
+Add the ability to remove a baseHeader on a per-request basis by setting the headers value to undefined

--- a/.changeset/gorgeous-crews-scream.md
+++ b/.changeset/gorgeous-crews-scream.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/solid-query': minor
+---
+
+Add solid-query support for extra args and custom headers

--- a/.changeset/pretty-books-marry.md
+++ b/.changeset/pretty-books-marry.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': minor
+---
+
+Allow custom API to allow extra args, and type them in the individual api calls

--- a/.changeset/spicy-kiwis-teach.md
+++ b/.changeset/spicy-kiwis-teach.md
@@ -1,0 +1,7 @@
+---
+'@ts-rest/core': minor
+'@ts-rest/react-query': minor
+'@ts-rest/solid-query': minor
+---
+
+Prettify the arguments of API calls, making it much clearer what data should be passed to ts-rest api calls (thanks @mattpocockuk!)

--- a/README.md
+++ b/README.md
@@ -25,19 +25,59 @@
 
 # Introduction
 
-ts-rest provides an RPC-like client side interface over your existing REST APIs, as well as allowing you define a _separate_ contract implementation rather than going for a 'implementation is the contract' approach, which is best suited for smaller or simpler APIs.
+ts-rest offers a simple way to define a contract for your API, which can be both consumed and implemented by your application, giving you end to end type safety without the hassle or code generation.
 
-If you have non typescript consumers, a public API, or maybe want to add type safety to your existing REST API? ts-rest is what you're looking for!
-
-## Features
+### Features
 
 - End to end type safety 🛟
-- Magic RPC-like API 🪄
-- Tiny bundle size 🌟 (1kb!)
+- RPC-like client side interface 📡
+- [Tiny bundle size 🌟](https://bundlephobia.com/package/@ts-rest/core) (1kb!)
 - Well-tested and production ready ✅
 - No Code Generation 🏃‍♀️
-- Zod support for body parsing 👮‍♀️
+- Zod support for runtime type checks 👮‍♀️
 - Full optional OpenAPI integration 📝
+
+### Super Simple Example
+
+Easily define your API contract somewhere shared
+
+```typescript
+const contract = c.contract({
+  getPosts: {
+    method: 'GET',
+    path: '/posts',
+    query: z.object({
+      skip: z.number(),
+      take: z.number(),
+    }), // <-- Zod schema
+    responses: {
+      200: c.response<Post[]>(), // <-- OR normal TS types
+    },
+  },
+});
+```
+
+Fulfil the contract on your sever, with a type-safe router:
+
+```typescript
+const router = s.router(contract, {
+  getPost: async ({ params: { id } }) => {
+    return {
+      status: 200,
+      body: prisma.post.findUnique({ where: { id } }),
+    };
+  },
+});
+```
+
+Consume the api on the client with a RPC-like interface:
+
+```typescript
+const result = await client.getPosts({
+  query: { skip: 0, take: 10 },
+  // ^-- Fully typed!
+});
+```
 
 ## Quickstart
 

--- a/apps/docs/docs/core/custom.md
+++ b/apps/docs/docs/core/custom.md
@@ -1,48 +1,109 @@
 # Custom Client
 
+By default, not specifying an `api` will use the default `tsRestFetchApi` which uses fetch under the hood.
+
+```typescript
+const client = initQueryClient(postsApi, {
+  baseUrl: 'http://localhost:5003',
+  baseHeaders: {},
+  // Uses `tsRestFetchApi` by default
+});
+```
+
+## Adding a Custom API
+
+If you want a custom api, you can reuse the internal `tsRestFetchApi` to add logging/custom logic to your requests!
+
+```typescript
+const client = initQueryClient(postsApi, {
+  baseUrl: 'http://localhost:5003',
+  baseHeaders: {},
+  api: async (args) => {
+    // Add anything you want here!
+
+    return tsRestFetchApi(args);
+  },
+});
+```
+
+### Extra Query Arguments
+
+By default when you make a ts-rest request you can pass in `params`, `query`, `body`, `headers` etc. However, sometimes you may want to pass in extra arguments to your custom api. You can do this by extending the type of the `args` parameter in your custom api.
+
+```typescript
+const client = initQueryClient(postsApi, {
+  baseUrl: 'http://localhost:5003',
+  baseHeaders: {},
+  api: async (args: ApiFetcherArgs & { myCustomArg?: string }) => {
+    if (args.myCustomArg) {
+      // do something with myCustomArg ✨
+    }
+
+    return tsRestFetchApi(args);
+  },
+});
+```
+
+The magical bit, is this is now fully typed and will work with your IDE's autocomplete! 🤯
+
+One note here, any extra args which are provided here but aren't typed correctly - e.g. if you've `@ts-expect-error`'d, **will still be passed to your api**. This is because the `args` parameter is a spread of all the other arguments you pass in to your api.
+
+```typescript
+client.getPosts({
+  query: { skip: 0, take: 10 },
+  myCustomArg: 'hello',
+  // ^-- autocomplete will work here, allowing you to extend ts-rest however you want
+});
+```
+
+:::tip
+You can use this to accomplish loads of patterns, such as adding a `cache` argument to your api, or adding a `logger` argument to your api - maybe you want to add an `onUploadProgress` argument to your api to track upload progress? You can do all of this with the `args` parameter!
+:::
+
+## Using Axios (custom api override)
+
+By default ts-rest ships with an incredibly simple fetch
+implementation for data fetching, because fetch requires zero extra
+dependencies and works perfectly for most use cases, however,
+sometimes you may want to use Axios, or another data fetching strategy, for that
+you can pass a `api` attribute to the `initClient` or `initQueryClient`.
+
 :::info
 The `credentials` option has no effect when using a custom client. Make sure you handle credentials in your custom client
 (e.g., setting `withCredentials` in axios).
 :::
 
-## Using Axios (custom api override)
-
-By default ts-rest ships with an incredibly simple fetch 
-implementation for data fetching, because fetch requires zero extra
-dependencies and works perfectly for most use cases, however, 
-sometimes you may want to use Axios, or another data fetching strategy, for that
-you can pass a `api` attribute to the `initClient` or `initQueryClient`.
-
 **Here's a basic example: **
+
 ```typescript
-import { contract } from './some-contract'
-import axios, { Method, AxiosError, AxiosResponse, isAxiosError } from 'axios'
+import { contract } from './some-contract';
+import axios, { Method, AxiosError, AxiosResponse, isAxiosError } from 'axios';
 
 const client = initClient(contract, {
-  baseUrl: "http://localhost:3333/api",
+  baseUrl: 'http://localhost:3333/api',
   baseHeaders: {
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
   },
   api: async ({ path, method, headers, body }) => {
-    const baseUrl = 'http://localhost:3333/api' //baseUrl is not available as a param, yet
+    const baseUrl = 'http://localhost:3333/api'; //baseUrl is not available as a param, yet
     try {
       const result = await axios.request({
         method: method as Method,
         url: `${this.baseUrl}/${path}`,
         headers,
         data: body,
-      })
-      return { status: result.status, body: result.data }
+      });
+      return { status: result.status, body: result.data };
     } catch (e: Error | AxiosError | any) {
       if (isAxiosError(e)) {
-        const error = e as AxiosError
-        const response = error.response as AxiosResponse
-        return { status: response.status, body: response.data }
+        const error = e as AxiosError;
+        const response = error.response as AxiosResponse;
+        return { status: response.status, body: response.data };
       }
-      throw e
+      throw e;
     }
   },
-})
+});
 ```
 
 Sometimes you need dynamic headers, IE passing in a Bearer token. There are two approaches you can take:
@@ -50,21 +111,21 @@ Sometimes you need dynamic headers, IE passing in a Bearer token. There are two 
 ### Instantiate the `client` with the header passed in:
 
 ```typescript
-import { contract } from './some-contract'
-import axios, { Method, AxiosError, AxiosResponse, isAxiosError } from 'axios'
+import { contract } from './some-contract';
+import axios, { Method, AxiosError, AxiosResponse, isAxiosError } from 'axios';
 
 export class SampleAPI {
-  token: string
+  token: string;
   constructor(params: { token: string }) {
-    this.token = params.token
-    this.baseUrl = 'http://localhost:3333/api'
+    this.token = params.token;
+    this.baseUrl = 'http://localhost:3333/api';
   }
   client = () => {
     return initClient(contract, {
       baseUrl: this.baseUrl,
       baseHeaders: {
         Authorization: `Bearer ${idToken}`,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       },
       api: async ({ path, method, headers, body }) => {
         try {
@@ -73,33 +134,33 @@ export class SampleAPI {
             url: `${this.baseUrl}/${path}`,
             headers,
             data: body,
-          })
-          return { status: result.status, body: result.data }
+          });
+          return { status: result.status, body: result.data };
         } catch (e: Error | AxiosError | any) {
           if (isAxiosError(e)) {
-            const error = e as AxiosError
-            const response = error.response as AxiosResponse
-            return { status: response.status, body: response.data }
+            const error = e as AxiosError;
+            const response = error.response as AxiosResponse;
+            return { status: response.status, body: response.data };
           }
-          throw e
+          throw e;
         }
       },
-    })
-  }
+    });
+  };
 }
 ```
 
 ### Instantiate the `client` but access a token during runtime:
 
-Here's an example using the `firebase/auth` library. Because `api` is async, you can `await` various calls when using the method. 
+Here's an example using the `firebase/auth` library. Because `api` is async, you can `await` various calls when using the method.
 
 ```typescript
-import { contract } from './some-contract'
-import axios, { Method, AxiosError, AxiosResponse, isAxiosError } from 'axios'
+import { contract } from './some-contract';
+import axios, { Method, AxiosError, AxiosResponse, isAxiosError } from 'axios';
 export class SampleAPI {
-  authInstance: Auth
+  authInstance: Auth;
   constructor(params: { authInstance: Auth }) {
-    this.authInstance = params.authInstance
+    this.authInstance = params.authInstance;
   }
   client = () => {
     return initClient(contract, {
@@ -108,29 +169,29 @@ export class SampleAPI {
         'Content-Type': 'application/json',
       },
       api: async ({ path, method, headers, body }) => {
-        const token = await this.authInstance.currentUser.getIdToken()
+        const token = await this.authInstance.currentUser.getIdToken();
         try {
           const result = await axios.request({
             method: method as Method,
             url: `${this.baseUrl}/${path}`,
-            headers: { 
+            headers: {
               ...headers,
-              Authorization: `Bearer ${idToken}` 
+              Authorization: `Bearer ${idToken}`,
             },
             data: body,
-          })
-          return { status: result.status, body: result.data }
+          });
+          return { status: result.status, body: result.data };
         } catch (e: Error | AxiosError | any) {
           if (isAxiosError(e)) {
-            const error = e as AxiosError
-            const response = error.response as AxiosResponse
-            return { status: response.status, body: response.data }
+            const error = e as AxiosError;
+            const response = error.response as AxiosResponse;
+            return { status: response.status, body: response.data };
           }
-          throw e
+          throw e;
         }
       },
-    })
-  }
+    });
+  };
 }
 ```
 

--- a/apps/docs/docs/core/fetch.md
+++ b/apps/docs/docs/core/fetch.md
@@ -1,6 +1,6 @@
-# Fetch Client
+# Client
 
-Connect to your ts-rest instance
+All of the client libraries (`@ts-rest/core`, `@ts-rest/react-query`, and `@ts-rest/solid-query`) all use the `initClient` or `initQueryClient` functions to create a client. These functions take a `baseUrl` and `baseHeaders` as the first two arguments, and then an optional `api` argument as the third argument.
 
 ```typescript
 export const client = initClient(router, {
@@ -9,15 +9,100 @@ export const client = initClient(router, {
 });
 ```
 
-## Query
+To customise the fetching behaviour, add an `api` function, please see [Custom API](/core/custom.md) for more information.
 
-**Query** against the contract, a _query_ is a function that does a GET request to the api.
+## Query and Mutate
+
+Your contract uses regular HTTP methods to define the type of request you want to make. We use this type to infer whether you are doing a `query` or a `mutate` request.
+
+Any requests that use the `GET` method will be treated as a `query` request, and any requests that use the `POST`, `PUT`, `PATCH` or `DELETE` methods will be treated as a `mutate` request.
 
 ```typescript
 const { data } = await client.posts.get();
+
+const { data, status } = await client.posts.create({
+  body: {
+    title: 'My Post',
+    content: 'This is my post',
+  },
+});
 ```
 
-### Typed Query Parameters
+Breaking down the arguments:
+
+- `body` - The body of the request, only used for `POST`, `PUT`, `PATCH` requests.
+- `query` - The query parameters of the request.
+- `headers` - The headers of the request (merged and overridden with `baseHeaders` in the client)
+- `params` - The path parameters of the request.
+
+:::tip Customise the API 🎨
+
+You can add your own custom arguments to the request, and they will be passed through to the `api` function - Read more here! [Custom API](/core/custom.md)
+
+```typescript
+const client = initQueryClient(postsApi, {
+  // ...
+  api: async (args: ApiFetcherArgs & { custom?: string }) => {
+    return tsRestFetchApi(args);
+  },
+});
+
+const { data } = await client.getPosts({
+  custom: 'argument',
+});
+```
+
+:::
+
+## Understanding the return type
+
+Because we type status codes, to check if the request was successful, we can use the `status` property.
+
+```typescript
+const data = await client.posts.create({
+  body: {
+    title: 'My Post',
+    content: 'This is my post',
+  },
+});
+
+if (data.status === 200) {
+  console.log('Success');
+} else {
+  console.log('Something went wrong');
+}
+```
+
+:::info
+
+The `data` property is typed as follows:
+
+```typescript
+const data: {
+    status: 200;
+    body: User
+} | {
+    status: 400 | 100 | 101 | 102 | 201 | 202 | 203 | 204 | 205 | 206 | 207 | 300 | 301 | 302 | 303 | 304 | 305 | 307 | ... 36 more ... | 511;
+    body: unknown;
+}
+```
+
+:::
+
+## Credentials (sending cookies)
+
+The `fetch()` function used by ts-rest does not send cookies in cross-origin requests by default unless the `credentials`
+option is set to `include`.
+
+```typescript
+const client = initClient(contract, {
+  baseUrl: 'http://localhost:3333/api',
+  baseHeaders: {},
+  credentials: 'include',
+});
+```
+
+## Typed Query Parameters
 
 By default, all query parameters are encoded as strings, however, you can use the `jsonQuery` option to encode query parameters as typed JSON values.
 Make sure to enable JSON query handling on the server as well.
@@ -54,61 +139,8 @@ This will ensure that you could pass Date objects in your client queries. They w
 
 :::
 
-## Mutate
-
-**Mutate** against the contract, a _mutation_ is a function that does a POST, PUT, PATCH or DELETE request to the api.
-
-```typescript
-const { data, status } = await client.posts.create({
-  body: {
-    title: 'My Post',
-    content: 'This is my post',
-  },
-});
-```
-
-:::info
-Because we type status codes, to check if the request was successful, we can use the `status` property.
-
-e.g.
-
-```typescript
-if (status === 200) {
-  console.log('Success');
-} else {
-  console.log('Something went wrong');
-}
-```
-
-## Return type
-
-```typescript
-const data: {
-    status: 200;
-    body: User
-} | {
-    status: 400 | 100 | 101 | 102 | 201 | 202 | 203 | 204 | 205 | 206 | 207 | 300 | 301 | 302 | 303 | 304 | 305 | 307 | ... 36 more ... | 511;
-    body: unknown;
-}
-```
-:::
-
-
-## Credentials (sending cookies)
-
-The `fetch()` function used by ts-rest does not send cookies in cross-origin requests by default unless the `credentials`
-option is set to `include`.
-
-```typescript
-const client = initClient(contract, {
-  baseUrl: "http://localhost:3333/api",
-  baseHeaders: {},
-  credentials: 'include'
-})
-```
-
 ## Notes About Basic Fetch Client
 
-We use the [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) API under the hood. 
+We use the [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) API under the hood.
 
 We support basic fetch calls for application/json and text/plain content types and do not support content-type missing in resource response (per [security standards](https://knowledge-base.secureflag.com/vulnerabilities/security_misconfiguration/lack_of_content_type_headers_vulnerability.html)). If you need to implement custom API logic (like content-type header is missing for some reason, or need to handle different content types), you can implement your own Client: https://ts-rest.com/docs/core/custom

--- a/apps/docs/docs/intro.md
+++ b/apps/docs/docs/intro.md
@@ -1,15 +1,55 @@
 # Introduction
 
-ts-rest provides an RPC-like client side interface over your existing REST APIs, as well as allowing you define a _separate_ contract implementation rather than going for a 'implementation is the contract' approach, which is best suited for smaller or simpler APIs.
+ts-rest offers a simple way to define a contract for your API, which can be both consumed and implemented by your application, giving you end to end type safety without the hassle or code generation.
 
-If you have non typescript consumers, a public API, or maybe want to add type safety to your existing REST API? ts-rest is what you're looking for!
-
-## Features
+### Features
 
 - End to end type safety 🛟
-- Magic RPC-like API 🪄
+- RPC-like client side interface 📡
 - [Tiny bundle size 🌟](https://bundlephobia.com/package/@ts-rest/core) (1kb!)
 - Well-tested and production ready ✅
 - No Code Generation 🏃‍♀️
-- Zod support for body parsing 👮‍♀️
+- Zod support for runtime type checks 👮‍♀️
 - Full optional OpenAPI integration 📝
+
+### Super Simple Example
+
+Easily define your API contract somewhere shared
+
+```typescript
+const contract = c.contract({
+  getPosts: {
+    method: 'GET',
+    path: '/posts',
+    query: z.object({
+      skip: z.number(),
+      take: z.number(),
+    }), // <-- Zod schema
+    responses: {
+      200: c.response<Post[]>(), // <-- OR normal TS types
+    },
+  },
+});
+```
+
+Fulfil the contract on your sever, with a type-safe router:
+
+```typescript
+const router = s.router(contract, {
+  getPost: async ({ params: { id } }) => {
+    return {
+      status: 200,
+      body: prisma.post.findUnique({ where: { id } }),
+    };
+  },
+});
+```
+
+Consume the api on the client with a RPC-like interface:
+
+```typescript
+const result = await client.getPosts({
+  query: { skip: 0, take: 10 },
+  // ^-- Fully typed!
+});
+```

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -4,9 +4,9 @@ import { InstallTabs } from '@site/src/components/InstallTabs';
 
 # Quickstart
 
-Setup is easy. 
+Setting up `ts-rest` is easy! You can opt to use either just the front-end, just the backend, or just the contract (if you really wanted)
 
-Once you understand how to use `ts-rest`, the developer experience is like butter.  🧈🪄✨
+Once you've got to grips with the basics, the developer experience is like butter. 🧈🪄✨
 
 ## Installation
 
@@ -14,29 +14,36 @@ Install the core package
 
 <InstallTabs packageName="@ts-rest/core" />
 
-
 ## Create a contract
 
 <Tabs groupId="contract">
   <TabItem value="zod" label="Zod">
 
-### **Install Zod** 
+### **Install Zod**
 
 <InstallTabs packageName="zod" />
 
-### **Enable `strict` in your `tsconfig.json`**
-  ```
-    "compilerOptions": {
-      ...
-      "strict": true
-    }
-  ```
-- *This is required as part of [Zod](https://github.com/colinhacks/zod#requirements).*
+:::caution Make sure to use `strict` with Zod
+Enable `strict` in your `tsconfig.json`! This is required as part of [Zod](https://github.com/colinhacks/zod#requirements)
 
+```
+  "compilerOptions": {
+    ...
+    "strict": true
+  }
+```
+
+If you don't do this, ts-rest will still work, but you may face performance issues [#162](https://github.com/ts-rest/ts-rest/issues/162)
+
+:::
 
 ### **Create a contract!**
 
-<p>This should ideally be shared between your consumers and producers, e.g. in a shared library in a monorepo, or a shared npm package. Think of this as your HTTP Schema that both your client and backend can use.</p>
+<p>
+  This should ideally be shared between your consumers and producers, e.g. in a
+  shared library in a monorepo, or a shared npm package. Think of this as your
+  HTTP Schema that both your client and backend can use.
+</p>
 
 ```typescript
 // contract.ts
@@ -75,9 +82,10 @@ export const contract = c.router({
   },
 });
 ```
+
 <p>
-  Zod also has some nice features, like enabling body
-  parsing and OpenAPI type generation.
+  Zod also has some nice features, like enabling body parsing and OpenAPI type
+  generation.
 </p>
 
   </TabItem>
@@ -154,11 +162,10 @@ export class PostController implements NestControllerInterface<typeof c> {
 }
 ```
 
-You can see that we're using the *runtime* object `c` in the `TsRest` decorator to automatically declare your path from the contract's `getPost` route. 
-We're also using the `RequestShapes` *Typescript Types* (which comes from the runtime object `c`) to ensure type safety of your contract *on* the Nest controller.
+You can see that we're using the _runtime_ object `c` in the `TsRest` decorator to automatically declare your path from the contract's `getPost` route.
+We're also using the `RequestShapes` _Typescript Types_ (which comes from the runtime object `c`) to ensure type safety of your contract _on_ the Nest controller.
 
-If you were to change the `body` return type to `{ body: true }` for example, this will give you a typescript error: Your `body` is defined as an *object* in the contract above, not boolean!
-
+If you were to change the `body` return type to `{ body: true }` for example, this will give you a typescript error: Your `body` is defined as an _object_ in the contract above, not boolean!
 
   </TabItem>
   <TabItem value="express" label="Express">

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -133,14 +133,13 @@ export default function Home(): JSX.Element {
 
       <div className="mt-24 container mx-auto">
         <div className=" bg-purple-100/40 dark:bg-purple-700/5 p-5 border-solid border-0 border-l-4 border-purple-600 dark:border-purple-700/80">
-          <h3>Elevator Pitch</h3>
+          <h3>Quick Dip</h3>
 
           <p>
-            ts-rest was initially designed for TS-first teams, in legacy
-            codebases, who are working towards improving stability and safety -
-            who may have limited resources to migrate to a new solution/tech
-            (such as GraphQL), and need a simple, safe API with a focus on DX
-            and adoption speed.
+            ts-rest was designed for and by TS-first teams who want to improve
+            the stability and safety without a large investment into a new
+            solution/tech (such as GraphQL), and need a simple, safe API with a
+            focus on DX and adoption speed.
           </p>
 
           <ul>
@@ -165,6 +164,20 @@ export default function Home(): JSX.Element {
             </li>
           </ul>
         </div>
+      </div>
+
+      <div className="container mt-24">
+        <h4 className="text-primary">Don't just take our word for it</h4>
+        <h1 className="">Give it a go</h1>
+        <p>
+          We've made a basic Stackblitz demo using a contract with Zod, client,
+          and server - try and follow through the instructions to learn how
+          ts-rest works!
+        </p>
+        <iframe
+          className="w-full h-[40rem]"
+          src="https://stackblitz.com/edit/typescript-x7pinn?embed=1&file=index.ts&view=editor"
+        />
       </div>
 
       <div className="container mt-24">

--- a/apps/example-microservice/web-app-solid/src/App.tsx
+++ b/apps/example-microservice/web-app-solid/src/App.tsx
@@ -4,17 +4,23 @@ import logo from './logo.svg';
 import styles from './App.module.css';
 import { postsApi } from '@ts-rest/example-microservice/util-posts-api';
 import { initQueryClient } from '@ts-rest/solid-query';
+import { ApiFetcherArgs, tsRestFetchApi } from '@ts-rest/core';
 
 const client = initQueryClient(postsApi, {
   baseUrl: 'http://localhost:5003',
   baseHeaders: {},
-
+  api: async (args: ApiFetcherArgs & { test?: string }) => {
+    return tsRestFetchApi(args);
+  },
 });
 
 const App: Component = () => {
   const updatePostThumbnail = client.updatePostThumbnail.createMutation({});
 
-  const data = client.getPosts.createQuery(() => ['posts'], { query: {} });
+  const data = client.getPosts.createQuery(() => ['posts'], {
+    query: {},
+    test: 'hi',
+  });
 
   console.log(data.data);
 

--- a/apps/example-next/tests/react-query.spec.tsx
+++ b/apps/example-next/tests/react-query.spec.tsx
@@ -171,7 +171,7 @@ describe('react-query', () => {
       path: 'http://api.com/health',
       body: undefined,
       headers: {
-        'Content-Type': 'application/json',
+        'content-type': 'application/json',
       },
     });
 
@@ -209,8 +209,8 @@ describe('react-query', () => {
       path: 'http://api.com/posts/1',
       body: undefined,
       headers: {
-        'Content-Type': 'application/json',
-        'X-Test': 'test',
+        'content-type': 'application/json',
+        'x-test': 'test',
       },
     });
   });
@@ -242,7 +242,7 @@ describe('react-query', () => {
       path: 'http://api.com/posts/1',
       body: undefined,
       headers: {
-        'Content-Type': 'application/xml',
+        'content-type': 'application/xml',
       },
     });
   });
@@ -274,7 +274,7 @@ describe('react-query', () => {
       path: 'http://api.com/posts/1',
       body: undefined,
       headers: {
-        'Content-Type': 'application/json',
+        'content-type': 'application/json',
       },
     });
   });
@@ -298,7 +298,7 @@ describe('react-query', () => {
       path: 'http://api.com/health',
       body: undefined,
       headers: {
-        'Content-Type': 'application/json',
+        'content-type': 'application/json',
       },
     });
 
@@ -328,7 +328,7 @@ describe('react-query', () => {
       path: 'http://api.com/health',
       body: undefined,
       headers: {
-        'Content-Type': 'application/json',
+        'content-type': 'application/json',
       },
     });
 
@@ -375,7 +375,7 @@ describe('react-query', () => {
         authorId: '1',
       }),
       headers: {
-        'Content-Type': 'application/json',
+        'content-type': 'application/json',
       },
     });
 
@@ -425,7 +425,7 @@ describe('react-query', () => {
       path: 'http://api.com/posts/1',
       body: undefined,
       headers: {
-        'Content-Type': 'application/json',
+        'content-type': 'application/json',
       },
     });
 
@@ -434,7 +434,7 @@ describe('react-query', () => {
       path: 'http://api.com/posts/2',
       body: undefined,
       headers: {
-        'Content-Type': 'application/json',
+        'content-type': 'application/json',
       },
     });
 
@@ -492,7 +492,7 @@ describe('react-query', () => {
       path: 'http://api.com/posts/1',
       body: undefined,
       headers: {
-        'Content-Type': 'application/json',
+        'content-type': 'application/json',
       },
     });
 
@@ -501,7 +501,7 @@ describe('react-query', () => {
       path: 'http://api.com/posts/2',
       body: undefined,
       headers: {
-        'Content-Type': 'application/json',
+        'content-type': 'application/json',
       },
     });
 
@@ -563,7 +563,7 @@ describe('react-query', () => {
       path: 'http://api.com/posts/1',
       body: undefined,
       headers: {
-        'Content-Type': 'application/json',
+        'content-type': 'application/json',
       },
     });
 
@@ -572,7 +572,7 @@ describe('react-query', () => {
       path: 'http://api.com/posts/2',
       body: undefined,
       headers: {
-        'Content-Type': 'application/json',
+        'content-type': 'application/json',
       },
     });
 

--- a/apps/example-next/tests/react-query.spec.tsx
+++ b/apps/example-next/tests/react-query.spec.tsx
@@ -215,6 +215,70 @@ describe('react-query', () => {
     });
   });
 
+  it('useQuery should override base headers', async () => {
+    api.mockResolvedValue(SUCCESS_RESPONSE);
+
+    const { result } = renderHook(
+      () =>
+        client.posts.getPost.useQuery(['post', '1'], {
+          params: {
+            id: '1',
+          },
+          headers: {
+            'Content-Type': 'application/xml',
+          },
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    expect(result.current.data).toStrictEqual(undefined);
+
+    expect(result.current.isLoading).toStrictEqual(true);
+
+    expect(api).toHaveBeenCalledWith({
+      method: 'GET',
+      path: 'http://api.com/posts/1',
+      body: undefined,
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+    });
+  });
+
+  it('useQuery should remove header if value is undefined', async () => {
+    api.mockResolvedValue(SUCCESS_RESPONSE);
+
+    const { result } = renderHook(
+      () =>
+        client.posts.getPost.useQuery(['post', '1'], {
+          params: {
+            id: '1',
+          },
+          headers: {
+            'Content-Type': undefined,
+          },
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    expect(result.current.data).toStrictEqual(undefined);
+
+    expect(result.current.isLoading).toStrictEqual(true);
+
+    expect(api).toHaveBeenCalledWith({
+      method: 'GET',
+      path: 'http://api.com/posts/1',
+      body: undefined,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  });
+
   it('useQuery should accept non-json string response', () => {
     api.mockResolvedValue({
       status: 200,

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -529,9 +529,9 @@ describe('custom api', () => {
     expect(argsCalledMock).toBeCalledWith(
       expect.objectContaining({
         headers: {
-          'Base-Header': 'foo',
-          'X-Test': 'test',
-          'Content-Type': 'application/json',
+          'base-header': 'foo',
+          'x-test': 'test',
+          'content-type': 'application/json',
         },
       })
     );
@@ -548,8 +548,26 @@ describe('custom api', () => {
     expect(argsCalledMock).toBeCalledWith(
       expect.objectContaining({
         headers: {
-          'Base-Header': 'bar',
-          'Content-Type': 'application/json',
+          'base-header': 'bar',
+          'content-type': 'application/json',
+        },
+      })
+    );
+  });
+
+  it('extra headers with different casing should override base headers', async () => {
+    await customClient.posts.getPost({
+      params: { id: '1' },
+      headers: {
+        'bAse-heaDer': 'bar',
+      },
+    });
+
+    expect(argsCalledMock).toBeCalledWith(
+      expect.objectContaining({
+        headers: {
+          'base-header': 'bar',
+          'content-type': 'application/json',
         },
       })
     );
@@ -570,9 +588,9 @@ describe('custom api', () => {
     expect(argsCalledMock).toBeCalledWith(
       expect.objectContaining({
         headers: {
-          'Base-Header': 'foo',
-          'Content-Type': 'application/json',
-          'X-Test': 'test',
+          'base-header': 'foo',
+          'content-type': 'application/json',
+          'x-test': 'test',
         },
         uploadProgress: expect.any(Function),
       })

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -48,11 +48,12 @@ type AppRouteBodyOrFormData<T extends AppRouteMutation> =
 /**
  * Extract any extra parameters from the client args
  */
-type ExtractExtraParametersFromClientArgs<TClientArgs extends ClientArgs> =
-  TClientArgs['api'] extends ApiFetcher
-    ? Omit<Parameters<TClientArgs['api']>[0], keyof Parameters<ApiFetcher>[0]>
-    : // eslint-disable-next-line @typescript-eslint/ban-types
-      {};
+export type ExtractExtraParametersFromClientArgs<
+  TClientArgs extends ClientArgs
+> = TClientArgs['api'] extends ApiFetcher
+  ? Omit<Parameters<TClientArgs['api']>[0], keyof Parameters<ApiFetcher>[0]>
+  : // eslint-disable-next-line @typescript-eslint/ban-types
+    {};
 
 type DataReturnArgsBase<
   TRoute extends AppRoute,
@@ -109,6 +110,7 @@ export interface ClientArgs {
   jsonQuery?: boolean;
 }
 
+
 export type ApiFetcherArgs = {
   path: string;
   method: string;
@@ -117,7 +119,7 @@ export type ApiFetcherArgs = {
   credentials?: RequestCredentials;
 };
 
-type ApiFetcher = (
+export type ApiFetcher = (
   args: ApiFetcherArgs
 ) => Promise<{ status: number; body: unknown }>;
 
@@ -156,14 +158,21 @@ const createFormData = (body: unknown) => {
   return formData;
 };
 
-export const fetchApi = (
-  path: string,
-  clientArgs: ClientArgs,
-  route: AppRoute,
-  body: unknown,
-  extraInputArgs: Record<string, unknown>,
-  headers: Record<string, string>
-) => {
+export const fetchApi = ({
+  path,
+  clientArgs,
+  route,
+  body,
+  extraInputArgs,
+  headers,
+}: {
+  path: string;
+  clientArgs: ClientArgs;
+  route: AppRoute;
+  body: unknown;
+  extraInputArgs: Record<string, unknown>;
+  headers: Record<string, string>;
+}) => {
   const apiFetcher = clientArgs.api || defaultApi;
 
   if (route.method !== 'GET' && route.contentType === 'multipart/form-data') {
@@ -230,14 +239,14 @@ export const getRouteQuery = <TAppRoute extends AppRoute>(
       !!clientArgs.jsonQuery
     );
 
-    return await fetchApi(
-      completeUrl,
+    return await fetchApi({
+      path: completeUrl,
       clientArgs,
       route,
       body,
       extraInputArgs,
-      headers || {}
-    );
+      headers: headers || {},
+    });
   };
 };
 

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -169,6 +169,12 @@ const createFormData = (body: unknown) => {
   return formData;
 };
 
+const normalizeHeaders = (headers: Record<string, string | undefined>) => {
+  return Object.fromEntries(
+    Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v])
+  );
+};
+
 export const fetchApi = ({
   path,
   clientArgs,
@@ -187,8 +193,8 @@ export const fetchApi = ({
   const apiFetcher = clientArgs.api || tsRestFetchApi;
 
   const combinedHeaders = {
-    ...clientArgs.baseHeaders,
-    ...headers,
+    ...normalizeHeaders(clientArgs.baseHeaders),
+    ...normalizeHeaders(headers),
   } as Record<string, string>;
 
   // Remove any headers that are set to undefined
@@ -214,7 +220,7 @@ export const fetchApi = ({
     method: route.method,
     credentials: clientArgs.credentials,
     headers: {
-      'Content-Type': 'application/json',
+      'content-type': 'application/json',
       ...combinedHeaders,
     },
     body:

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -186,24 +186,15 @@ export const fetchApi = ({
 }) => {
   const apiFetcher = clientArgs.api || tsRestFetchApi;
 
-  /**
-   * Combined headers should combine baseHeaders and headers from the api call, but
-   * if there are any duplicate keys, the headers from the api call should take precedence
-   * over the baseHeaders
-   *
-   * if the header is undefined, it should unset the header
-   */
-  const combinedHeaders = new Map();
+  const combinedHeaders = {
+    ...clientArgs.baseHeaders,
+    ...headers,
+  } as Record<string, string>;
 
-  Object.entries(clientArgs.baseHeaders).forEach(([key, value]) => {
-    combinedHeaders.set(key, value);
-  });
-
-  Object.entries(headers).forEach(([key, value]) => {
-    if (value === undefined) {
-      combinedHeaders.delete(key);
-    } else {
-      combinedHeaders.set(key, value);
+  // Remove any headers that are set to undefined
+  Object.keys(combinedHeaders).forEach((key) => {
+    if (combinedHeaders[key] === undefined) {
+      delete combinedHeaders[key];
     }
   });
 
@@ -212,7 +203,7 @@ export const fetchApi = ({
       path,
       method: route.method,
       credentials: clientArgs.credentials,
-      headers: Object.fromEntries(combinedHeaders),
+      headers: combinedHeaders,
       body: body instanceof FormData ? body : createFormData(body),
       ...extraInputArgs,
     });
@@ -224,7 +215,7 @@ export const fetchApi = ({
     credentials: clientArgs.credentials,
     headers: {
       'Content-Type': 'application/json',
-      ...Object.fromEntries(combinedHeaders),
+      ...combinedHeaders,
     },
     body:
       body !== null && body !== undefined ? JSON.stringify(body) : undefined,

--- a/libs/ts-rest/core/src/lib/dsl.spec.ts
+++ b/libs/ts-rest/core/src/lib/dsl.spec.ts
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { z } from 'zod';
+import { initContract } from './dsl';
+import type { Equal, Expect } from './test-helpers';
+const c = initContract();
+
+describe('contract', () => {
+  it('should be typed correctly', () => {
+    const contract = c.router({
+      getPost: {
+        method: 'GET',
+        path: '/posts/:id',
+        responses: {
+          200: z.object({
+            id: z.number(),
+          }),
+        },
+      },
+    });
+
+    type ContractShape = Expect<
+      Equal<
+        typeof contract,
+        {
+          getPost: {
+            method: 'GET';
+            path: '/posts/:id';
+            responses: {
+              200: z.ZodObject<
+                {
+                  id: z.ZodNumber;
+                },
+                'strip',
+                z.ZodTypeAny,
+                {
+                  id: number;
+                },
+                {
+                  id: number;
+                }
+              >;
+            };
+          };
+        }
+      >
+    >;
+  });
+
+  it('should be typed correctly with nested routers', () => {
+    const contract = c.router({
+      posts: {
+        getPost: {
+          method: 'GET',
+          path: '/posts/:id',
+          responses: {
+            200: z.object({
+              id: z.number(),
+            }),
+          },
+        },
+      },
+    });
+
+    type ContractShape = Expect<
+      Equal<
+        typeof contract,
+        {
+          posts: {
+            getPost: {
+              method: 'GET';
+              path: '/posts/:id';
+              responses: {
+                200: z.ZodObject<
+                  {
+                    id: z.ZodNumber;
+                  },
+                  'strip',
+                  z.ZodTypeAny,
+                  {
+                    id: number;
+                  },
+                  {
+                    id: number;
+                  }
+                >;
+              };
+            };
+          };
+        }
+      >
+    >;
+  });
+
+  it('should be typed without zod', () => {
+    const contract = c.router({
+      getPost: {
+        method: 'GET',
+        path: '/posts/:id',
+        responses: {
+          200: c.body<{ id: number }>(),
+        },
+      },
+    });
+
+    type ContractShape = Expect<
+      Equal<
+        typeof contract,
+        {
+          getPost: {
+            method: 'GET';
+            path: '/posts/:id';
+            responses: {
+              200: {
+                id: number;
+              };
+            };
+          };
+        }
+      >
+    >;
+  });
+});

--- a/libs/ts-rest/core/src/lib/test-helpers.ts
+++ b/libs/ts-rest/core/src/lib/test-helpers.ts
@@ -1,0 +1,7 @@
+export type Equal<a, b> = (<T>() => T extends a ? 1 : 2) extends <
+  T
+>() => T extends b ? 1 : 2
+  ? true
+  : false;
+
+export type Expect<a extends true> = a;

--- a/libs/ts-rest/core/src/lib/type-utils.spec.ts
+++ b/libs/ts-rest/core/src/lib/type-utils.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { z } from 'zod';
-import { ZodInferOrType } from './type-utils';
+import { Equal, Expect } from './test-helpers';
+import { AreAllPropertiesOptional, ZodInferOrType } from './type-utils';
 
 const zodObject = z.object({ title: z.string() });
 type Test1 = ZodInferOrType<typeof zodObject>;
@@ -11,3 +12,23 @@ type Test2 = ZodInferOrType<typeof zodObject>;
 type Test3 = ZodInferOrType<{ title: string }>;
 
 it.todo('should infer type');
+
+type AreAllPropertiesOptional1 = Expect<
+  Equal<AreAllPropertiesOptional<{ a: string; b?: string }>, false>
+>;
+
+type AreAllPropertiesOptional2 = Expect<
+  Equal<AreAllPropertiesOptional<{ a?: string; b?: string }>, true>
+>;
+
+type AreAllPropertiesOptional3 = Expect<
+  Equal<
+    AreAllPropertiesOptional<{
+      params: {
+        id: string;
+      };
+      headers?: Record<string, string> | undefined;
+    }>,
+    false
+  >
+>;

--- a/libs/ts-rest/core/src/lib/type-utils.ts
+++ b/libs/ts-rest/core/src/lib/type-utils.ts
@@ -98,3 +98,8 @@ export type OptionalIfAllOptional<
       [K in keyof T]: AreAllPropertiesOptional<T[K]> extends true ? K : never;
     }[keyof T]
 >;
+
+export type Prettify<T> = {
+  [K in keyof T]: T[K];
+  // eslint-disable-next-line @typescript-eslint/ban-types
+} & {};

--- a/libs/ts-rest/react-query/src/lib/react-query.ts
+++ b/libs/ts-rest/react-query/src/lib/react-query.ts
@@ -211,13 +211,13 @@ type DataReturnMutation<
   options?: UseMutationOptions<
     DataResponse<TAppRoute>,
     ErrorResponse<TAppRoute>,
-    Without<DataReturnArgs<TAppRoute, TClientArgs>, never>,
+    Prettify<Without<DataReturnArgs<TAppRoute, TClientArgs>, never>>,
     unknown
   >
 ) => UseMutationResult<
   DataResponse<TAppRoute>,
   ErrorResponse<TAppRoute>,
-  Without<DataReturnArgs<TAppRoute, TClientArgs>, never>,
+  Prettify<Without<DataReturnArgs<TAppRoute, TClientArgs>, never>>,
   unknown
 >;
 

--- a/libs/ts-rest/react-query/src/lib/react-query.ts
+++ b/libs/ts-rest/react-query/src/lib/react-query.ts
@@ -85,7 +85,12 @@ type DataReturnArgsBase<
       ? never
       : AppRouteMutationType<TRoute['query']>
     : never;
-  headers?: Record<string, string>;
+  /**
+   * Additional headers to send with the request, merged over baseHeaders,
+   *
+   * Unset a header by setting it to undefined
+   */
+  headers?: Record<string, string | undefined>;
 } & ExtractExtraParametersFromClientArgs<TClientArgs>;
 
 type DataReturnArgs<

--- a/libs/ts-rest/solid-query/src/lib/solid-query.ts
+++ b/libs/ts-rest/solid-query/src/lib/solid-query.ts
@@ -19,45 +19,52 @@ import {
   AppRouteQuery,
   AppRouter,
   ClientArgs,
+  ExtractExtraParametersFromClientArgs,
   fetchApi,
   getCompleteUrl,
   getRouteQuery,
   HTTPStatusCode,
   isAppRoute,
   PathParamsFromUrl,
+  Prettify,
   SuccessfulHttpStatusCode,
   Without,
   ZodInferOrType,
   ZodInputOrType,
 } from '@ts-rest/core';
 
-type RecursiveProxyObj<T extends AppRouter> = {
+type RecursiveProxyObj<T extends AppRouter, TClientArgs extends ClientArgs> = {
   [TKey in keyof T]: T[TKey] extends AppRoute
-    ? Without<UseQueryArgs<T[TKey]>, never>
+    ? Without<UseQueryArgs<T[TKey], TClientArgs>, never>
     : T[TKey] extends AppRouter
-    ? RecursiveProxyObj<T[TKey]>
+    ? RecursiveProxyObj<T[TKey], TClientArgs>
     : never;
 };
 
 type AppRouteMutationType<T> = ZodInputOrType<T>;
 
-type UseQueryArgs<TAppRoute extends AppRoute> = {
+type UseQueryArgs<
+  TAppRoute extends AppRoute,
+  TClientArgs extends ClientArgs
+> = {
   createQuery: TAppRoute extends AppRouteQuery
-    ? DataReturnQuery<TAppRoute>
+    ? DataReturnQuery<TAppRoute, TClientArgs>
     : never;
   createInfiniteQuery: TAppRoute extends AppRouteQuery
-    ? DataReturnInfiniteQuery<TAppRoute>
+    ? DataReturnInfiniteQuery<TAppRoute, TClientArgs>
     : never;
-  query: TAppRoute extends AppRouteQuery ? AppRouteFunction<TAppRoute> : never;
+  query: TAppRoute extends AppRouteQuery
+    ? AppRouteFunction<TAppRoute, TClientArgs>
+    : never;
   createMutation: TAppRoute extends AppRouteMutation
-    ? DataReturnMutation<TAppRoute>
+    ? DataReturnMutation<TAppRoute, TClientArgs>
     : never;
   mutation: TAppRoute extends AppRouteMutation
-    ? AppRouteFunction<TAppRoute>
+    ? AppRouteFunction<TAppRoute, TClientArgs>
     : never;
 };
 
-type DataReturnArgs<TRoute extends AppRoute> = {
+type DataReturnArgs<TRoute extends AppRoute, TClientArgs extends ClientArgs> = {
   body: TRoute extends AppRouteMutation
     ? AppRouteMutationType<TRoute['body']> extends null
       ? never
@@ -69,7 +76,13 @@ type DataReturnArgs<TRoute extends AppRoute> = {
       ? never
       : AppRouteMutationType<TRoute['query']>
     : never;
-};
+  /**
+   * Additional headers to send with the request, merged over baseHeaders,
+   *
+   * Unset a header by setting it to undefined
+   */
+  headers?: Record<string, string>;
+} & ExtractExtraParametersFromClientArgs<TClientArgs>;
 
 /**
  * Split up the data and error to support solid-query style
@@ -103,9 +116,12 @@ type DataResponse<T extends AppRoute> = SuccessResponseMapper<T['responses']>;
 type ErrorResponse<T extends AppRoute> = ErrorResponseMapper<T['responses']>;
 
 // Used on X.createQuery
-type DataReturnQuery<TAppRoute extends AppRoute> = (
+type DataReturnQuery<
+  TAppRoute extends AppRoute,
+  TClientArgs extends ClientArgs
+> = (
   queryKey: () => QueryKey,
-  args: Without<DataReturnArgs<TAppRoute>, never>,
+  args: Prettify<Without<DataReturnArgs<TAppRoute, TClientArgs>, never>>,
   options?: CreateQueryOptions<
     DataResponse<TAppRoute>,
     ErrorResponse<TAppRoute>
@@ -113,11 +129,14 @@ type DataReturnQuery<TAppRoute extends AppRoute> = (
 ) => CreateQueryResult<DataResponse<TAppRoute>, ErrorResponse<TAppRoute>>;
 
 // Used on X.useInfiniteQuery
-type DataReturnInfiniteQuery<TAppRoute extends AppRoute> = (
+type DataReturnInfiniteQuery<
+  TAppRoute extends AppRoute,
+  TClientArgs extends ClientArgs
+> = (
   queryKey: () => QueryKey,
   args: (
     context: QueryFunctionContext<QueryKey>
-  ) => Without<DataReturnArgs<TAppRoute>, never>,
+  ) => Prettify<Without<DataReturnArgs<TAppRoute, TClientArgs>, never>>,
   options?: CreateInfiniteQueryOptions<
     DataResponse<TAppRoute>,
     ErrorResponse<TAppRoute>
@@ -128,17 +147,20 @@ type DataReturnInfiniteQuery<TAppRoute extends AppRoute> = (
 >;
 
 // Used pn X.createMutation
-type DataReturnMutation<TAppRoute extends AppRoute> = (
+type DataReturnMutation<
+  TAppRoute extends AppRoute,
+  TClientArgs extends ClientArgs
+> = (
   options?: CreateMutationOptions<
     DataResponse<TAppRoute>,
     ErrorResponse<TAppRoute>,
-    Without<DataReturnArgs<TAppRoute>, never>,
+    Prettify<Without<DataReturnArgs<TAppRoute, TClientArgs>, never>>,
     unknown
   >
 ) => CreateMutationResult<
   DataResponse<TAppRoute>,
   ErrorResponse<TAppRoute>,
-  Without<DataReturnArgs<TAppRoute>, never>,
+  Without<DataReturnArgs<TAppRoute, TClientArgs>, never>,
   unknown
 >;
 
@@ -148,10 +170,12 @@ const getRouteUseQuery = <TAppRoute extends AppRoute>(
 ) => {
   return (
     queryKey: () => QueryKey,
-    args: DataReturnArgs<TAppRoute>,
+    args: any,
     options?: CreateQueryOptions<TAppRoute['responses']>
   ) => {
     const dataFn: QueryFunction<TAppRoute['responses']> = async () => {
+      const { query, params, body, headers, ...extraInputArgs } = args || {};
+
       const path = getCompleteUrl(
         args.query,
         clientArgs.baseUrl,
@@ -165,6 +189,8 @@ const getRouteUseQuery = <TAppRoute extends AppRoute>(
         clientArgs,
         route,
         body: args.body,
+        headers: args.headers || {},
+        extraInputArgs,
       });
 
       // If the response is not a 2XX, throw an error to be handled by solid-query
@@ -179,19 +205,27 @@ const getRouteUseQuery = <TAppRoute extends AppRoute>(
   };
 };
 
-const getRouteUseInfiniteQuery = <TAppRoute extends AppRoute>(
+const getRouteUseInfiniteQuery = <
+  TAppRoute extends AppRoute,
+  TClientArgs extends ClientArgs
+>(
   route: TAppRoute,
-  clientArgs: ClientArgs
+  clientArgs: TClientArgs
 ) => {
   return (
     queryKey: () => QueryKey,
-    args: (context: QueryFunctionContext) => DataReturnArgs<TAppRoute>,
+    args: (
+      context: QueryFunctionContext
+    ) => DataReturnArgs<TAppRoute, TClientArgs>,
     options?: CreateInfiniteQueryOptions<TAppRoute['responses']>
   ) => {
     const dataFn: QueryFunction<TAppRoute['responses']> = async (
       infiniteQueryParams
     ) => {
       const resultingQueryArgs = args(infiniteQueryParams);
+
+      const { query, params, body, headers, ...extraInputArgs } =
+        (resultingQueryArgs as any) || {};
 
       const path = getCompleteUrl(
         resultingQueryArgs.query,
@@ -206,6 +240,8 @@ const getRouteUseInfiniteQuery = <TAppRoute extends AppRoute>(
         clientArgs,
         route,
         body: resultingQueryArgs.body,
+        headers: headers || {},
+        extraInputArgs,
       });
 
       // If the response is not a 2XX, throw an error to be handled by solid-query
@@ -220,12 +256,20 @@ const getRouteUseInfiniteQuery = <TAppRoute extends AppRoute>(
   };
 };
 
-const getRouteUseMutation = <TAppRoute extends AppRoute>(
+const getRouteUseMutation = <
+  TAppRoute extends AppRoute,
+  TClientArgs extends ClientArgs
+>(
   route: TAppRoute,
-  clientArgs: ClientArgs
+  clientArgs: TClientArgs
 ) => {
   return (options?: CreateMutationOptions<TAppRoute['responses']>) => {
-    const mutationFunction = async (args: DataReturnArgs<TAppRoute>) => {
+    const mutationFunction = async (
+      args: DataReturnArgs<TAppRoute, TClientArgs>
+    ) => {
+      const { query, params, body, headers, ...extraInputArgs } =
+        (args as any) || {};
+
       const path = getCompleteUrl(
         args.query,
         clientArgs.baseUrl,
@@ -239,6 +283,8 @@ const getRouteUseMutation = <TAppRoute extends AppRoute>(
         clientArgs,
         route,
         body: args.body,
+        headers: headers || {},
+        extraInputArgs,
       });
 
       // If the response is not a 2XX, throw an error to be handled by solid-query
@@ -256,12 +302,18 @@ const getRouteUseMutation = <TAppRoute extends AppRoute>(
   };
 };
 
-export type InitClientReturn<T extends AppRouter> = RecursiveProxyObj<T>;
+export type InitClientReturn<
+  T extends AppRouter,
+  TClientArgs extends ClientArgs
+> = RecursiveProxyObj<T, TClientArgs>;
 
-export const initQueryClient = <T extends AppRouter>(
+export const initQueryClient = <
+  T extends AppRouter,
+  TClientArgs extends ClientArgs
+>(
   router: T,
-  args: ClientArgs
-): InitClientReturn<T> => {
+  args: TClientArgs
+): InitClientReturn<T, TClientArgs> => {
   return Object.fromEntries(
     Object.entries(router).map(([key, subRouter]) => {
       if (isAppRoute(subRouter)) {

--- a/libs/ts-rest/solid-query/src/lib/solid-query.ts
+++ b/libs/ts-rest/solid-query/src/lib/solid-query.ts
@@ -160,7 +160,12 @@ const getRouteUseQuery = <TAppRoute extends AppRoute>(
         !!clientArgs.jsonQuery
       );
 
-      const result = await fetchApi(path, clientArgs, route, args.body);
+      const result = await fetchApi({
+        path,
+        clientArgs,
+        route,
+        body: args.body,
+      });
 
       // If the response is not a 2XX, throw an error to be handled by solid-query
       if (!String(result.status).startsWith('2')) {
@@ -196,12 +201,12 @@ const getRouteUseInfiniteQuery = <TAppRoute extends AppRoute>(
         !!clientArgs.jsonQuery
       );
 
-      const result = await fetchApi(
+      const result = await fetchApi({
         path,
         clientArgs,
         route,
-        resultingQueryArgs.body
-      );
+        body: resultingQueryArgs.body,
+      });
 
       // If the response is not a 2XX, throw an error to be handled by solid-query
       if (!String(result.status).startsWith('2')) {
@@ -229,7 +234,12 @@ const getRouteUseMutation = <TAppRoute extends AppRoute>(
         !!clientArgs.jsonQuery
       );
 
-      const result = await fetchApi(path, clientArgs, route, args.body);
+      const result = await fetchApi({
+        path,
+        clientArgs,
+        route,
+        body: args.body,
+      });
 
       // If the response is not a 2XX, throw an error to be handled by solid-query
       if (!String(result.status).startsWith('2')) {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@tanstack/query-core": "^4.10.3",
     "@tanstack/react-query": "^4.2.3",
     "@tanstack/react-query-devtools": "^4.2.3",
-    "@tanstack/solid-query": "^4.8.0",
+    "@tanstack/solid-query": "4.24.9",
     "@types/body-parser": "^1.19.2",
     "@types/multer": "^1.4.7",
     "@types/qs": "^6.9.7",
@@ -93,7 +93,7 @@
     "reflect-metadata": "^0.1.13",
     "regenerator-runtime": "0.13.9",
     "rxjs": "^7.0.0",
-    "solid-js": "^1.5.1",
+    "solid-js": "^1.6.11",
     "swagger-ui-express": "^4.5.0",
     "tailwind-rn": "^4.2.0",
     "tailwindcss": "3.2.4",
@@ -103,7 +103,7 @@
     "typedoc-plugin-markdown": "^3.14.0",
     "uuid": "^8.3.2",
     "vitest": "^0.23.4",
-    "zod": "^3.18.0",
+    "zod": "3.20.6",
     "zustand": "^4.1.1"
   },
   "devDependencies": {
@@ -194,7 +194,7 @@
     "typescript": "4.9.4",
     "url-loader": "^4.1.1",
     "vite": "^3.1.2",
-    "vite-plugin-solid": "2.3.0",
+    "vite-plugin-solid": "2.5.0",
     "webpack": "^5.75.0",
     "webpack-merge": "^5.8.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
       '@tanstack/query-core': ^4.10.3
       '@tanstack/react-query': ^4.2.3
       '@tanstack/react-query-devtools': ^4.2.3
-      '@tanstack/solid-query': ^4.8.0
+      '@tanstack/solid-query': 4.24.9
       '@testing-library/jest-dom': 5.16.5
       '@testing-library/jest-native': 5.3.0
       '@testing-library/react': 13.4.0
@@ -151,7 +151,7 @@ importers:
       rollup-plugin-cleanup: ^3.2.1
       rxjs: ^7.0.0
       sass: 1.55.0
-      solid-js: ^1.5.1
+      solid-js: ^1.6.11
       style-loader: ^3.3.0
       stylus: ^0.55.0
       stylus-loader: ^7.1.0
@@ -170,15 +170,15 @@ importers:
       url-loader: ^4.1.1
       uuid: ^8.3.2
       vite: ^3.1.2
-      vite-plugin-solid: 2.3.0
+      vite-plugin-solid: 2.5.0
       vitest: ^0.23.4
       webpack: ^5.75.0
       webpack-merge: ^5.8.0
-      zod: ^3.18.0
+      zod: 3.20.6
       zustand: ^4.1.1
     dependencies:
       '@actions/core': 1.10.0
-      '@anatine/zod-openapi': 1.12.0_jaqnetbcjcsissttd5r7v75rg4
+      '@anatine/zod-openapi': 1.12.0_gp44v63vh7o54popb62d7r7as4
       '@babel/runtime': 7.20.6
       '@changesets/cli': 2.24.4
       '@docusaurus/core': 2.0.1_jcfe4ra3qxngmagfuvsim2yzgq
@@ -201,7 +201,7 @@ importers:
       '@tanstack/query-core': 4.10.3
       '@tanstack/react-query': 4.3.4_2so4eo66zr774rftk5qlya5ltu
       '@tanstack/react-query-devtools': 4.3.5_hbsvmtv74eglyqgnta4rgheflu
-      '@tanstack/solid-query': 4.8.0_solid-js@1.5.6
+      '@tanstack/solid-query': 4.24.9_solid-js@1.6.11
       '@types/body-parser': 1.19.2
       '@types/multer': 1.4.7
       '@types/qs': 6.9.7
@@ -247,7 +247,7 @@ importers:
       reflect-metadata: 0.1.13
       regenerator-runtime: 0.13.9
       rxjs: 7.5.6
-      solid-js: 1.5.6
+      solid-js: 1.6.11
       swagger-ui-express: 4.5.0_express@4.18.1
       tailwind-rn: 4.2.0_vk6pvwhrvowtex4dvhgqxqnzju
       tailwindcss: 3.2.4_v776zzvn44o7tpgzieipaairwm
@@ -257,7 +257,7 @@ importers:
       typedoc-plugin-markdown: 3.14.0_typedoc@0.23.24
       uuid: 8.3.2
       vitest: 0.23.4_sass@1.55.0+stylus@0.55.0
-      zod: 3.19.1
+      zod: 3.20.6
       zustand: 4.1.1_react@18.2.0
     devDependencies:
       '@babel/preset-react': 7.18.6
@@ -347,7 +347,7 @@ importers:
       typescript: 4.9.4
       url-loader: 4.1.1_webpack@5.75.0
       vite: 3.1.2_sass@1.55.0+stylus@0.55.0
-      vite-plugin-solid: 2.3.0_solid-js@1.5.6+vite@3.1.2
+      vite-plugin-solid: 2.5.0_solid-js@1.6.11+vite@3.1.2
       webpack: 5.75.0_@swc+core@1.3.1
       webpack-merge: 5.8.0
 
@@ -544,7 +544,7 @@ packages:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.15
 
-  /@anatine/zod-openapi/1.12.0_jaqnetbcjcsissttd5r7v75rg4:
+  /@anatine/zod-openapi/1.12.0_gp44v63vh7o54popb62d7r7as4:
     resolution: {integrity: sha512-ZdkmQFXdc2us0nTBPWiJ3joHxsZoc5G79hKB8QzUuo73zp2A4t4TlBmOjS+hJfMnTBATfJutrlN/wK4DUq6ztg==}
     peerDependencies:
       openapi3-ts: ^2.0.0 || ^3.0.0
@@ -552,7 +552,7 @@ packages:
     dependencies:
       openapi3-ts: 2.0.2
       ts-deepmerge: 4.0.0
-      zod: 3.19.1
+      zod: 3.20.6
     dev: false
 
   /@anatine/zod-openapi/1.12.0_openapi3-ts@2.0.2:
@@ -731,7 +731,7 @@ packages:
       '@babel/parser': 7.20.5
       '@babel/template': 7.18.10
       '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -799,7 +799,7 @@ packages:
       '@babel/parser': 7.20.5
       '@babel/template': 7.18.10
       '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -824,7 +824,7 @@ packages:
     resolution: {integrity: sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
 
@@ -832,14 +832,14 @@ packages:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.18.9:
     resolution: {integrity: sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
 
   /@babel/helper-compilation-targets/7.19.1_@babel+core@7.19.1:
     resolution: {integrity: sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==}
@@ -1019,33 +1019,26 @@ packages:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
 
   /@babel/helper-function-name/7.19.0:
     resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
 
   /@babel/helper-member-expression-to-functions/7.18.9:
     resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
-
-  /@babel/helper-module-imports/7.16.0:
-    resolution: {integrity: sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.20.5
-    dev: true
+      '@babel/types': 7.21.0
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
@@ -1064,7 +1057,7 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.18.10
       '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1079,7 +1072,7 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.18.10
       '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1087,7 +1080,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
 
   /@babel/helper-plugin-utils/7.10.4:
     resolution: {integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==}
@@ -1106,7 +1099,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.19.0
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1120,7 +1113,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.19.0
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1134,7 +1127,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.19.0
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1146,7 +1139,7 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.18.9
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1154,25 +1147,25 @@ packages:
     resolution: {integrity: sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
 
   /@babel/helper-simple-access/7.20.2:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
 
   /@babel/helper-skip-transparent-expression-wrappers/7.18.9:
     resolution: {integrity: sha512-imytd2gHi3cJPsybLRbmFrF7u5BIEuI2cNheyKi3/iOBC63kNn3q8Crn2xVuESli0aM4KYsyEqKyS7lFL8YVtw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
 
   /@babel/helper-string-parser/7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
@@ -1193,7 +1186,7 @@ packages:
       '@babel/helper-function-name': 7.19.0
       '@babel/template': 7.18.10
       '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1203,7 +1196,7 @@ packages:
     dependencies:
       '@babel/template': 7.18.10
       '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1213,7 +1206,7 @@ packages:
     dependencies:
       '@babel/template': 7.18.10
       '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1230,14 +1223,14 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
 
   /@babel/parser/7.20.5:
     resolution: {integrity: sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6:
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
@@ -2124,6 +2117,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.1
       '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.20.5:
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
@@ -3881,7 +3875,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6
       '@babel/plugin-transform-dotall-regex': 7.18.6
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
       esutils: 2.0.3
 
   /@babel/preset-modules/0.1.5_@babel+core@7.19.1:
@@ -3893,7 +3887,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.19.1
       '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.19.1
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
       esutils: 2.0.3
 
   /@babel/preset-modules/0.1.5_@babel+core@7.20.5:
@@ -3905,7 +3899,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.5
       '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
       esutils: 2.0.3
 
   /@babel/preset-react/7.18.6:
@@ -4042,7 +4036,7 @@ packages:
     dependencies:
       '@babel/code-frame': 7.18.6
       '@babel/parser': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
 
   /@babel/traverse/7.19.1:
     resolution: {integrity: sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==}
@@ -4072,7 +4066,7 @@ packages:
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -4088,6 +4082,14 @@ packages:
 
   /@babel/types/7.20.5:
     resolution: {integrity: sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.19.4
+      '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+
+  /@babel/types/7.21.0:
+    resolution: {integrity: sha512-uR7NWq2VNFnDi7EYqiRz2Jv/VQIu38tu64Zy8TX2nQFQ6etJ9V/Rr2msW8BS132mum2rL645qpDrLtAJtVpuow==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.19.4
@@ -8730,7 +8732,7 @@ packages:
     resolution: {integrity: sha512-1hnUxxjd83EAxbL4a0JDJoD3Dao3hmjvyvyEV8PzWmLK3B9m9NPlW7GKjFyoWE8nM7HnXzPcmmSyOW8yOddSXw==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
       entities: 4.4.0
 
   /@svgr/plugin-jsx/6.5.1_@svgr+core@6.3.1:
@@ -9015,12 +9017,12 @@ packages:
     resolution: {integrity: sha512-+ME02sUmBfx3Pjd+0XtEthK8/4rVMD2jcxvnW9DSgFONpKtpjzfRzjY4ykzpDw1QEo2eoPvl7NS8J5mNI199aA==}
     dev: false
 
-  /@tanstack/query-core/4.3.4:
-    resolution: {integrity: sha512-NLAe3j5Vk1yYEtoPP5fPGPjRzkZPx67KUM3f14L3InziJZJ0wVecCh7uKfgYkbRKJSeq6PlbND7iuCGdTplN6Q==}
+  /@tanstack/query-core/4.24.9:
+    resolution: {integrity: sha512-pZQ2NpdaHzx8gPPkAPh06d6zRkjfonUzILSYBXrdHDapP2eaBbGsx5L4/dMF+fyAglFzQZdDDzZgAykbM20QVw==}
     dev: false
 
-  /@tanstack/query-core/4.8.0:
-    resolution: {integrity: sha512-PVcSqAWboFA86eNgtHTOjfHjBkNuFGAM6kPH82p1ibx1R76f7EjedZ+LZi4ZnW4ppoSl/+hUtCgWsiNQ2ViLTw==}
+  /@tanstack/query-core/4.3.4:
+    resolution: {integrity: sha512-NLAe3j5Vk1yYEtoPP5fPGPjRzkZPx67KUM3f14L3InziJZJ0wVecCh7uKfgYkbRKJSeq6PlbND7iuCGdTplN6Q==}
     dev: false
 
   /@tanstack/react-query-devtools/4.3.5_hbsvmtv74eglyqgnta4rgheflu:
@@ -9056,13 +9058,13 @@ packages:
       use-sync-external-store: 1.2.0_react@18.2.0
     dev: false
 
-  /@tanstack/solid-query/4.8.0_solid-js@1.5.6:
-    resolution: {integrity: sha512-mwgvd6QGYHYdIJyKG7aL5zMNLYKJPoPEWMR8P+8wHGBbHoVTL2LPfkWcP3MMlyDdY7esPOocbhpufgmOPNDRVQ==}
+  /@tanstack/solid-query/4.24.9_solid-js@1.6.11:
+    resolution: {integrity: sha512-pGeNCgAJZU4FNRRm74Mpihuq4KQSWMBlKwEhNCJEIg/9agprpxgfKhXDzVYRzk5pkUIxC7nUkOFqLQSZhAe7bA==}
     peerDependencies:
-      solid-js: ^1.5.4
+      solid-js: ^1.5.7
     dependencies:
-      '@tanstack/query-core': 4.8.0
-      solid-js: 1.5.6
+      '@tanstack/query-core': 4.24.9
+      solid-js: 1.6.11
     dev: false
 
   /@testing-library/dom/8.18.0:
@@ -9225,20 +9227,20 @@ packages:
   /@types/babel__generator/7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
     dev: true
 
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
       '@babel/parser': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
     dev: true
 
   /@types/babel__traverse/7.18.1:
     resolution: {integrity: sha512-FSdLaZh2UxaMuLp9lixWaHq/golWTRWOnRsAXzDTDSDOQLuZb1nsdCt6pJSPWSEQt2eFZ2YVk3oYhn+1kLMeMA==}
     dependencies:
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
     dev: true
 
   /@types/body-parser/1.19.2:
@@ -11086,7 +11088,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
       '@types/babel__core': 7.1.19
       '@types/babel__traverse': 7.18.1
     dev: true
@@ -11096,21 +11098,22 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
       '@types/babel__core': 7.1.19
       '@types/babel__traverse': 7.18.1
     dev: true
 
-  /babel-plugin-jsx-dom-expressions/0.34.10_@babel+core@7.19.1:
-    resolution: {integrity: sha512-YTuTvhpGWuD67JTgb/oFDkQMEzsAG7GKBSl+WNTMkmD9tUBkDNZoKijsDRA2R+zV2VJz2aPaXu3gwPkIIbhMtg==}
+  /babel-plugin-jsx-dom-expressions/0.35.16_@babel+core@7.20.5:
+    resolution: {integrity: sha512-Z8vaeXRdtI4qyq3bmQiLjiZnbjn2Rr0mjpXMwN+QxHbWjtlAFOJSHlkcxbrwPz/DdcfSgkmZM0Atvt/zMLeLyA==}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.20.12
     dependencies:
-      '@babel/core': 7.19.1
-      '@babel/helper-module-imports': 7.16.0
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.19.1
-      '@babel/types': 7.20.5
-      html-entities: 2.3.2
+      '@babel/core': 7.20.5
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.5
+      '@babel/types': 7.21.0
+      html-entities: 2.3.3
+      validate-html-nesting: 1.2.1
     dev: true
 
   /babel-plugin-macros/2.8.0:
@@ -11366,13 +11369,13 @@ packages:
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.20.5
     dev: true
 
-  /babel-preset-solid/1.5.6_@babel+core@7.19.1:
-    resolution: {integrity: sha512-DETqhEygtRq627y5jII5szev495CvbPZJDTaosCbRWdbBh7nMBPI9JuVBUdWs56M2D4mqYa6Z2vH4mdIS6srwA==}
+  /babel-preset-solid/1.6.10_@babel+core@7.20.5:
+    resolution: {integrity: sha512-qBLjzeWmgY5jX11sJg/lriXABYdClfJrJJrIHaT6G5EuGhxhm6jn7XjqXjLBZHBgy5n/Z+iqJ5YfQj8KG2jKTA==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.19.1
-      babel-plugin-jsx-dom-expressions: 0.34.10_@babel+core@7.19.1
+      '@babel/core': 7.20.5
+      babel-plugin-jsx-dom-expressions: 0.35.16_@babel+core@7.20.5
     dev: true
 
   /backo2/1.0.2:
@@ -17116,10 +17119,6 @@ packages:
     resolution: {integrity: sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==}
     dev: true
 
-  /html-entities/2.3.2:
-    resolution: {integrity: sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==}
-    dev: true
-
   /html-entities/2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
 
@@ -18088,8 +18087,8 @@ packages:
     dependencies:
       call-bind: 1.0.2
 
-  /is-what/4.1.7:
-    resolution: {integrity: sha512-DBVOQNiPKnGMxRMLIYSwERAS5MVY1B7xYiGnpgctsOFvVDz9f9PFXXxMcTOHuoqYp4NK9qFYQaIC1NRRxLMpBQ==}
+  /is-what/4.1.8:
+    resolution: {integrity: sha512-yq8gMao5upkPoGEU9LsB2P+K3Kt8Q3fQFCGyNCWOAnJAMzEXVV9drYb0TXr42TTliLLhKIBvulgAXgtLLnwzGA==}
     engines: {node: '>=12.13'}
     dev: true
 
@@ -19813,12 +19812,11 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /merge-anything/5.0.4:
-    resolution: {integrity: sha512-YFsDeY5A9SLXhL21Qn15wCWewRUW6wMTxQF4SuPe9bNdr1wsjiE44Rp8FQUTCtwO0WLdlKiFzhAVE5tlf857Tg==}
+  /merge-anything/5.1.4:
+    resolution: {integrity: sha512-7PWKwGOs5WWcpw+/OvbiFiAvEP6bv/QHiicigpqMGKIqPPAtGhBLR8LFJW+Zu6m9TXiR/a8+AiPlGG0ko1ruoQ==}
     engines: {node: '>=12.13'}
     dependencies:
-      is-what: 4.1.7
-      ts-toolbelt: 9.6.0
+      is-what: 4.1.8
     dev: true
 
   /merge-descriptors/1.0.1:
@@ -20053,7 +20051,7 @@ packages:
       '@babel/core': 7.20.5
       '@babel/generator': 7.20.5
       '@babel/parser': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
       babel-preset-fbjs: 3.4.0_@babel+core@7.20.5
       metro: 0.72.3
       metro-babel-transformer: 0.72.3
@@ -20079,7 +20077,7 @@ packages:
       '@babel/parser': 7.20.5
       '@babel/template': 7.18.10
       '@babel/traverse': 7.20.5
-      '@babel/types': 7.20.5
+      '@babel/types': 7.21.0
       absolute-path: 0.0.0
       accepts: 1.3.8
       async: 3.2.4
@@ -24767,12 +24765,12 @@ packages:
       uuid: 8.3.2
       websocket-driver: 0.7.4
 
-  /solid-js/1.5.6:
-    resolution: {integrity: sha512-EA7hjMIEdDUuV6Fk3WUQ2fPx7sRnhjl+3M59zj6Sh+c7c3JF3N1cSViBvX8MYJG9vEBEqKQBZUfKHPe/9JgKvQ==}
+  /solid-js/1.6.11:
+    resolution: {integrity: sha512-JquQQHPArGq+i2PLURxJ99Pcz2/1docpbycSio/cKSA0SeI3z5zRjy0TNcH4NRYvbOLrcini+iovXwnexKabyw==}
     dependencies:
       csstype: 3.1.1
 
-  /solid-refresh/0.4.1_solid-js@1.5.6:
+  /solid-refresh/0.4.1_solid-js@1.6.11:
     resolution: {integrity: sha512-v3tD/OXQcUyXLrWjPW1dXZyeWwP7/+GQNs8YTL09GBq+5FguA6IejJWUvJDrLIA4M0ho9/5zK2e9n+uy+4488g==}
     peerDependencies:
       solid-js: ^1.3
@@ -24780,7 +24778,7 @@ packages:
       '@babel/generator': 7.20.5
       '@babel/helper-module-imports': 7.18.6
       '@babel/types': 7.20.5
-      solid-js: 1.5.6
+      solid-js: 1.6.11
     dev: true
 
   /sort-css-media-queries/2.1.0:
@@ -26106,10 +26104,6 @@ packages:
       typescript: 4.9.4
     dev: true
 
-  /ts-toolbelt/9.6.0:
-    resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
-    dev: true
-
   /tsconfig-paths-webpack-plugin/3.5.2:
     resolution: {integrity: sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==}
     dependencies:
@@ -26792,6 +26786,10 @@ packages:
   /valid-url/1.0.9:
     resolution: {integrity: sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==}
 
+  /validate-html-nesting/1.2.1:
+    resolution: {integrity: sha512-T1ab131NkP3BfXB7KUSgV7Rhu81R2id+L6NaJ7NypAAG5iV6gXnPpQE5RK1fvb+3JYsPTL+ihWna5sr5RN9gaQ==}
+    dev: true
+
   /validate-npm-package-license/3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
     dependencies:
@@ -26849,19 +26847,20 @@ packages:
       vfile-message: 2.0.4
     dev: false
 
-  /vite-plugin-solid/2.3.0_solid-js@1.5.6+vite@3.1.2:
-    resolution: {integrity: sha512-N2sa54C3UZC2nN5vpj5o6YP+XdIAZW6n6xv8OasxNAcAJPFeZT7EOVvumL0V4c8hBz1yuYniMWdESY8807fVSg==}
+  /vite-plugin-solid/2.5.0_solid-js@1.6.11+vite@3.1.2:
+    resolution: {integrity: sha512-VneGd3RyFJvwaiffsqgymeMaofn0IzQLPwDzafTV2f1agoWeeJlk5VrI5WqT9BTtLe69vNNbCJWqLhHr9fOdDw==}
     peerDependencies:
-      solid-js: ^1.3.17
-      vite: ^3.0.0
+      solid-js: ^1.3.17 || ^1.4.0 || ^1.5.0 || ^1.6.0
+      vite: ^3.0.0 || ^4.0.0
     dependencies:
-      '@babel/core': 7.19.1
-      '@babel/preset-typescript': 7.18.6_@babel+core@7.19.1
-      babel-preset-solid: 1.5.6_@babel+core@7.19.1
-      merge-anything: 5.0.4
-      solid-js: 1.5.6
-      solid-refresh: 0.4.1_solid-js@1.5.6
+      '@babel/core': 7.20.5
+      '@babel/preset-typescript': 7.18.6_@babel+core@7.20.5
+      babel-preset-solid: 1.6.10_@babel+core@7.20.5
+      merge-anything: 5.1.4
+      solid-js: 1.6.11
+      solid-refresh: 0.4.1_solid-js@1.6.11
       vite: 3.1.2_sass@1.55.0+stylus@0.55.0
+      vitefu: 0.2.4_vite@3.1.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -26893,6 +26892,17 @@ packages:
       stylus: 0.55.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  /vitefu/0.2.4_vite@3.1.2:
+    resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      vite: 3.1.2_sass@1.55.0+stylus@0.55.0
+    dev: true
 
   /vitest/0.23.4_sass@1.55.0+stylus@0.55.0:
     resolution: {integrity: sha512-iukBNWqQAv8EKDBUNntspLp9SfpaVFbmzmM0sNcnTxASQZMzRw3PsM6DMlsHiI+I6GeO5/sYDg3ecpC+SNFLrQ==}
@@ -27858,8 +27868,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  /zod/3.19.1:
-    resolution: {integrity: sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==}
+  /zod/3.20.6:
+    resolution: {integrity: sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==}
     dev: false
 
   /zustand/4.1.1_react@18.2.0:


### PR DESCRIPTION
An action-packed PR! 

- [ ] Docs, I want to document the client args :) 

- Allow API client args to be set in the custom API fetcher
- Allow headers to be overridden
- Prettify query args (thanks @mattpocock) 

<img width="713" alt="before" src="https://user-images.githubusercontent.com/47489826/220468389-30c2fefb-58e2-427f-b995-0e287154d8e9.png">
<img width="644" alt="after" src="https://user-images.githubusercontent.com/47489826/220468384-1fb84232-f09a-4e8a-a467-60acf17c26f4.png">

