### PR TITLE
fix: restore getRouteResponses method

### DIFF
--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -273,6 +273,21 @@ export const getRouteQuery = <TAppRoute extends AppRoute>(
   };
 };
 
+export type ApiResponseForRoute<T extends AppRoute> = ApiRouteResponse<
+  T['responses']
+>;
+
+// takes a router and returns response types for each AppRoute
+// does not support nested routers, yet
+
+export function getRouteResponses<T extends AppRouter>(router: T) {
+  return {} as {
+    [K in keyof typeof router]: typeof router[K] extends AppRoute
+      ? ApiResponseForRoute<typeof router[K]>
+      : 'not a route';
+  };
+}
+
 export type InitClientReturn<
   T extends AppRouter,
   TClientArgs extends ClientArgs


### PR DESCRIPTION
The getRouteResponses method was removed (mistakenly?), but provides a nice utility function for the client to access response types. The method is still documented here https://ts-rest.com/docs/core/#response-types