### PR TITLE
restore getRouteResponses (for now), add ResponsesForRouter

### DIFF
--- a/apps/docs/docs/core/core.md
+++ b/apps/docs/docs/core/core.md
@@ -119,19 +119,14 @@ export const contract = c.router({
 
 ## Response Types
 
-If you need to quickly extract the Response types from a given Contract, you can use `getRouteResponses`.
-
-:warning: This does not support nested contracts yet. You need to pass in a defined contract. 
-
-`getRouteResponses(router)` returns an empty object with defined response types for a contract's HTTP method. 
+If you need to quickly extract the Response types from a given Contract, you can use the `ResponsesForRouter` type.
 
 ```typescript
-import { getRouteResponses } from '@ts-rest/core'
+import { ResponsesForRouter } from '@ts-rest/core'
 import { contract } from './contract'
 
 //  initContract() must called prior
-const contractResponses = getRouteResponses(contract)
-type ResponseShapes = typeof contractResponses
+type ResponseShapes = ResponsesForRouter<typeof contract>
 
 async function someHttpCall(req: Request): Promise<ResponseShapes['getPosts']> {
   return ...

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -295,21 +295,6 @@ export const getRouteQuery = <TAppRoute extends AppRoute>(
   };
 };
 
-export type ApiResponseForRoute<T extends AppRoute> = ApiRouteResponse<
-  T['responses']
->;
-
-// takes a router and returns response types for each AppRoute
-// does not support nested routers, yet
-
-export function getRouteResponses<T extends AppRouter>(router: T) {
-  return {} as {
-    [K in keyof typeof router]: typeof router[K] extends AppRoute
-      ? ApiResponseForRoute<typeof router[K]>
-      : 'not a route';
-  };
-}
-
 export type InitClientReturn<
   T extends AppRouter,
   TClientArgs extends ClientArgs

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -91,6 +91,28 @@ export type ApiRouteResponse<T> =
       body: unknown;
     };
 
+export type ResponseForRoute<T extends AppRoute> = ApiRouteResponse<
+  T['responses']
+>
+
+export type ResponsesForRouter<T extends AppRouter> = {
+  [K in keyof T]: T[K] extends AppRoute
+  ? ResponseForRoute<T[K]>
+  : T[K] extends AppRouter ? ResponsesForRouter<T[K]> : never;
+};
+
+/**
+ * 
+ * @deprecated
+ */
+export function getRouteResponses<T extends AppRouter>(router: T) {
+  return {} as {
+    [K in keyof typeof router]: typeof router[K] extends AppRoute
+      ? ResponseForRoute<typeof router[K]>
+      : 'not a route';
+  };
+}
+
 /**
  * Returned from a mutation or query call
  */


### PR DESCRIPTION
fixes #191 

@Gabrola mentions that 

>  In order to provide this functionality publicly we'll need to distinguish between inferring the Input schema and Output schema for Zod depending on whether the type will be used by the client or server; kind of similar to how trpc has inferRouterInputs and inferRouterOutputs.

> For example for responses, we'd need to use the Zod Output on the client, and Zod Input on the server. For everything else (query, body, etc.) it's vice-versa.

I do eventually think we should take this idea and run with it eventually, however, for the sake of brevity, we need to do the following: 
- we should restore the original method
- add a "better" way of using the original method
- document the release versions that this is affected by

We should be careful moving forward on removing methods without proper communication/documentation. 