### PR TITLE
feat: add type inference helpers

### DIFF
--- a/.changeset/purple-comics-notice.md
+++ b/.changeset/purple-comics-notice.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': minor
+---
+
+Added inference type helpers

--- a/apps/docs/docs/core/core.md
+++ b/apps/docs/docs/core/core.md
@@ -116,21 +116,3 @@ export const contract = c.router({
   },
 });
 ```
-
-## Response Types
-
-If you need to quickly extract the Response types from a given Contract, you can use the `ResponsesForRouter` type.
-
-```typescript
-import { ResponsesForRouter } from '@ts-rest/core'
-import { contract } from './contract'
-
-//  initContract() must called prior
-type ResponseShapes = ResponsesForRouter<typeof contract>
-
-async function someHttpCall(req: Request): Promise<ResponseShapes['getPosts']> {
-  return ...
-}
-```
-
-This is particularly useful for Services/Functions/Lambdas that do not use frameworks like Express or Nestjs. 

--- a/apps/docs/docs/core/form-data.mdx
+++ b/apps/docs/docs/core/form-data.mdx
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# multipart/form-data
+# File Uploading
 
 ts-rest supports multipart/form-data requests, this is useful for uploading files or working with FormData from a form.
 

--- a/apps/docs/docs/core/infer-types.md
+++ b/apps/docs/docs/core/infer-types.md
@@ -1,0 +1,69 @@
+# Inferring Types
+
+Often, we need to manually extract the request or responses types of specific contract endpoints, so functions, services, lambdas, React components, etc. can be safely typed
+when there is no automatic type inference.
+
+We have separate type helpers for server-side and client-side code since we need to infer either the Input or Output Zod types depending on
+where the code is used.
+
+## Inferring Response Types
+
+To get the response types of a contract or a specific endpoint, we have the following type helpers:
+
+- `InferResponsesForServer<AppRouter | AppRoute, OptionalHttpStatusCode>`
+- `InferResponsesForClient<AppRouter | AppRoute, OptionalHttpStatusCode>`
+
+```typescript
+import { InferResponsesForServer } from '@ts-rest/core';
+import { contract } from './contract';
+
+type ResponseShapes = InferResponsesForServer<typeof contract>;
+
+async function someHttpCall(req: Request): Promise<ResponseShapes['getPosts']> {
+  return ...;
+}
+
+function someServiceCall(): InferResponsesForServer<typeof contract.getPosts> {
+  return ...;
+}
+```
+
+### Inferring Response Body
+
+If you need to infer the response body for a defined response status of a specific endpoint, we can use the following type helpers:
+
+- `InferResponseBodyForServer<AppRoute, OptionalHttpStatusCode>`
+- `InferResponseBodyForClient<AppRoute, OptionalHttpStatusCode>`
+
+This is syntactic sugar for `InferResponsesForServer<AppRoute, OptionalHttpStatusCode & keyof AppRoute['responses']>['body']`
+
+```typescript
+import React from 'react';
+import { InferResponseBodyForClient } from '@ts-rest/core';
+import { contract } from './contract';
+
+type Post = InferResponseBodyForClient<typeof contract.getPost, 200>;
+
+function PostComponent(props: { post: Post }) {
+  return <>...</>;
+}
+```
+
+## Inferring Request Types
+
+To get the request (path params, query params, body) types of a contract or a specific endpoint, we have the following type helpers:
+
+- `InferRequestForServer<AppRouter | AppRoute>`
+- `InferRequestForClient<AppRouter | AppRoute>`
+
+```typescript
+import { InferRequestForServer, InferResponsesForServer } from '@ts-rest/core';
+import { contract } from './contract';
+
+type GetPostRequest = InferRequestForServer<typeof contract.getPost>;
+type GetPostResponse = InferResponsesForServer<typeof contract.getPost>;
+
+async function getPostLambdaHandler({ params, query }: GetPostRequest): Promise<GetPostResponse> {
+  return ...;
+}
+```

--- a/apps/docs/docs/core/infer-types.md
+++ b/apps/docs/docs/core/infer-types.md
@@ -10,20 +10,20 @@ where the code is used.
 
 To get the response types of a contract or a specific endpoint, we have the following type helpers:
 
-- `InferResponsesForServer<AppRouter | AppRoute, OptionalHttpStatusCode>`
-- `InferResponsesForClient<AppRouter | AppRoute, OptionalHttpStatusCode>`
+- `ServerInferResponses<AppRouter | AppRoute, OptionalHttpStatusCode>`
+- `ClientInferResponses<AppRouter | AppRoute, OptionalHttpStatusCode>`
 
 ```typescript
-import { InferResponsesForServer } from '@ts-rest/core';
+import { ServerInferResponses } from '@ts-rest/core';
 import { contract } from './contract';
 
-type ResponseShapes = InferResponsesForServer<typeof contract>;
+type ResponseShapes = ServerInferResponses<typeof contract>;
 
 async function someHttpCall(req: Request): Promise<ResponseShapes['getPosts']> {
   return ...;
 }
 
-function someServiceCall(): InferResponsesForServer<typeof contract.getPosts> {
+function someServiceCall(): ServerInferResponses<typeof contract.getPosts> {
   return ...;
 }
 ```
@@ -32,17 +32,17 @@ function someServiceCall(): InferResponsesForServer<typeof contract.getPosts> {
 
 If you need to infer the response body for a defined response status of a specific endpoint, we can use the following type helpers:
 
-- `InferResponseBodyForServer<AppRoute, OptionalHttpStatusCode>`
-- `InferResponseBodyForClient<AppRoute, OptionalHttpStatusCode>`
+- `ServerInferResponseBody<AppRoute, OptionalHttpStatusCode>`
+- `ClientInferResponseBody<AppRoute, OptionalHttpStatusCode>`
 
-This is syntactic sugar for `InferResponsesForServer<AppRoute, OptionalHttpStatusCode & keyof AppRoute['responses']>['body']`
+This is syntactic sugar for `ServerInferResponses<AppRoute, OptionalHttpStatusCode & keyof AppRoute['responses']>['body']`
 
 ```typescript
 import React from 'react';
-import { InferResponseBodyForClient } from '@ts-rest/core';
+import { ClientInferResponseBody } from '@ts-rest/core';
 import { contract } from './contract';
 
-type Post = InferResponseBodyForClient<typeof contract.getPost, 200>;
+type Post = ClientInferResponseBody<typeof contract.getPost, 200>;
 
 function PostComponent(props: { post: Post }) {
   return <>...</>;
@@ -53,15 +53,15 @@ function PostComponent(props: { post: Post }) {
 
 To get the request (path params, query params, body) types of a contract or a specific endpoint, we have the following type helpers:
 
-- `InferRequestForServer<AppRouter | AppRoute>`
-- `InferRequestForClient<AppRouter | AppRoute>`
+- `ServerInferRequest<AppRouter | AppRoute>`
+- `ClientInferRequest<AppRouter | AppRoute>`
 
 ```typescript
-import { InferRequestForServer, InferResponsesForServer } from '@ts-rest/core';
+import { ServerInferRequest, ServerInferResponses } from '@ts-rest/core';
 import { contract } from './contract';
 
-type GetPostRequest = InferRequestForServer<typeof contract.getPost>;
-type GetPostResponse = InferResponsesForServer<typeof contract.getPost>;
+type GetPostRequest = ServerInferRequest<typeof contract.getPost>;
+type GetPostResponse = ServerInferResponses<typeof contract.getPost>;
 
 async function getPostLambdaHandler({ params, query }: GetPostRequest): Promise<GetPostResponse> {
   return ...;

--- a/apps/docs/sidebars.js
+++ b/apps/docs/sidebars.js
@@ -66,6 +66,7 @@ const sidebars = {
         { type: 'doc', id: 'core/core' },
         { type: 'doc', id: 'core/fetch' },
         { type: 'doc', id: 'core/custom' },
+        { type: 'doc', id: 'core/infer-types' },
         { type: 'doc', id: 'core/errors' },
         { type: 'doc', id: 'core/form-data' },
       ],

--- a/libs/ts-rest/core/src/index.ts
+++ b/libs/ts-rest/core/src/index.ts
@@ -7,3 +7,4 @@ export * from './lib/type-utils';
 export * from './lib/zod-utils';
 export * from './lib/server';
 export * from './lib/response-validation-error';
+export * from './lib/infer-types';

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -99,14 +99,14 @@ export type ApiRouteResponse<T> =
     };
 
 /**
- * @deprecated Only safe to use on the client-side. Use `InferResponsesForServer`/`InferResponsesForClient` instead.
+ * @deprecated Only safe to use on the client-side. Use `ServerInferResponses`/`ClientInferResponses` instead.
  */
 export type ApiResponseForRoute<T extends AppRoute> = ApiRouteResponse<
   T['responses']
 >;
 
 /**
- * @deprecated Only safe to use on the client-side. Use `InferResponsesForServer`/`InferResponsesForClient` instead.
+ * @deprecated Only safe to use on the client-side. Use `ServerInferResponses`/`ClientInferResponses` instead.
  */
 export function getRouteResponses<T extends AppRouter>(router: T) {
   return {} as {

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -34,10 +34,17 @@ export type PathParamsFromUrl<T extends AppRoute> = ParamsFromUrl<
 /**
  * Merge `PathParamsFromUrl<T>` with pathParams schema if it exists
  */
-export type PathParamsWithCustomValidators<T extends AppRoute> =
-  T['pathParams'] extends undefined
-    ? PathParamsFromUrl<T>
-    : Merge<PathParamsFromUrl<T>, ZodInferOrType<T['pathParams']>>;
+export type PathParamsWithCustomValidators<
+  T extends AppRoute,
+  TClientOrServer extends 'client' | 'server' = 'server'
+> = T['pathParams'] extends undefined
+  ? PathParamsFromUrl<T>
+  : Merge<
+      PathParamsFromUrl<T>,
+      TClientOrServer extends 'server'
+        ? ZodInferOrType<T['pathParams']>
+        : ZodInputOrType<T['pathParams']>
+    >;
 
 // Allow FormData if the contentType is multipart/form-data
 type AppRouteBodyOrFormData<T extends AppRouteMutation> =
@@ -91,24 +98,20 @@ export type ApiRouteResponse<T> =
       body: unknown;
     };
 
-export type ResponseForRoute<T extends AppRoute> = ApiRouteResponse<
+/**
+ * @deprecated Only safe to use on the client-side. Use `InferResponsesForServer`/`InferResponsesForClient` instead.
+ */
+export type ApiResponseForRoute<T extends AppRoute> = ApiRouteResponse<
   T['responses']
->
-
-export type ResponsesForRouter<T extends AppRouter> = {
-  [K in keyof T]: T[K] extends AppRoute
-  ? ResponseForRoute<T[K]>
-  : T[K] extends AppRouter ? ResponsesForRouter<T[K]> : never;
-};
+>;
 
 /**
- * 
- * @deprecated
+ * @deprecated Only safe to use on the client-side. Use `InferResponsesForServer`/`InferResponsesForClient` instead.
  */
 export function getRouteResponses<T extends AppRouter>(router: T) {
   return {} as {
     [K in keyof typeof router]: typeof router[K] extends AppRoute
-      ? ResponseForRoute<typeof router[K]>
+      ? ApiResponseForRoute<typeof router[K]>
       : 'not a route';
   };
 }

--- a/libs/ts-rest/core/src/lib/infer-types.spec.ts
+++ b/libs/ts-rest/core/src/lib/infer-types.spec.ts
@@ -2,12 +2,12 @@ import { z } from 'zod';
 import { initContract } from './dsl';
 import { Equal, Expect } from './test-helpers';
 import {
-  InferRequestForClient,
-  InferRequestForServer,
-  InferResponseBodyForClient,
-  InferResponseBodyForServer,
-  InferResponsesForClient,
-  InferResponsesForServer,
+  ClientInferRequest,
+  ServerInferRequest,
+  ClientInferResponseBody,
+  ServerInferResponseBody,
+  ClientInferResponses,
+  ServerInferResponses,
 } from './infer-types';
 import { HTTPStatusCode } from './status-codes';
 
@@ -86,9 +86,9 @@ const contract = c.router({
 });
 
 it('type inference helpers', () => {
-  type InferResponsesForServerTest = Expect<
+  type ServerInferResponsesTest = Expect<
     Equal<
-      InferResponsesForServer<typeof contract>,
+      ServerInferResponses<typeof contract>,
       {
         getPost:
           | {
@@ -122,9 +122,9 @@ it('type inference helpers', () => {
     >
   >;
 
-  type InferResponsesForServerTest2 = Expect<
+  type ServerInferResponsesTest2 = Expect<
     Equal<
-      InferResponsesForServer<typeof contract, 200>,
+      ServerInferResponses<typeof contract, 200>,
       {
         getPost: {
           status: 200;
@@ -148,9 +148,9 @@ it('type inference helpers', () => {
     >
   >;
 
-  type InferResponsesForServerTest3 = Expect<
+  type ServerInferResponsesTest3 = Expect<
     Equal<
-      InferResponsesForServer<typeof contract, 401>,
+      ServerInferResponses<typeof contract, 401>,
       {
         getPost: {
           status: 401;
@@ -174,9 +174,9 @@ it('type inference helpers', () => {
     >
   >;
 
-  type InferResponsesForClientTest = Expect<
+  type ClientInferResponsesTest = Expect<
     Equal<
-      InferResponsesForClient<typeof contract>,
+      ClientInferResponses<typeof contract>,
       {
         getPost:
           | {
@@ -213,23 +213,23 @@ it('type inference helpers', () => {
     >
   >;
 
-  type InferResponseBodyForServerTest = Expect<
+  type ServerInferResponseBodyTest = Expect<
     Equal<
-      InferResponseBodyForServer<typeof contract.getPost, 200>,
+      ServerInferResponseBody<typeof contract.getPost, 200>,
       { title?: string | undefined; id: number; content: string }
     >
   >;
 
-  type InferResponseBodyForClientTest = Expect<
+  type ClientInferResponseBodyTest = Expect<
     Equal<
-      InferResponseBodyForClient<typeof contract.getPost, 200>,
+      ClientInferResponseBody<typeof contract.getPost, 200>,
       { title: string; id: number; content: string }
     >
   >;
 
-  type InferRequestForServerTest = Expect<
+  type ServerInferRequestTest = Expect<
     Equal<
-      InferRequestForServer<typeof contract>,
+      ServerInferRequest<typeof contract>,
       {
         getPost: {
           query: { includeComments: boolean };
@@ -251,9 +251,9 @@ it('type inference helpers', () => {
     >
   >;
 
-  type InferRequestForClientTest = Expect<
+  type ClientInferRequestTest = Expect<
     Equal<
-      InferRequestForClient<typeof contract>,
+      ClientInferRequest<typeof contract>,
       {
         getPost: {
           query: { includeComments?: boolean | undefined };

--- a/libs/ts-rest/core/src/lib/infer-types.spec.ts
+++ b/libs/ts-rest/core/src/lib/infer-types.spec.ts
@@ -1,0 +1,280 @@
+import { z } from 'zod';
+import { initContract } from './dsl';
+import { Equal, Expect } from './test-helpers';
+import {
+  InferRequestForClient,
+  InferRequestForServer,
+  InferResponseBodyForClient,
+  InferResponseBodyForServer,
+  InferResponsesForClient,
+  InferResponsesForServer,
+} from './infer-types';
+import { HTTPStatusCode } from './status-codes';
+
+const c = initContract();
+
+const contract = c.router({
+  getPost: {
+    method: 'GET',
+    path: '/posts/:id',
+    pathParams: z.object({
+      id: z.string().transform((id) => Number(id)),
+    }),
+    query: z.object({
+      includeComments: z.boolean().default(false),
+    }),
+    responses: {
+      200: z.object({
+        id: z.number(),
+        title: z.string().default('Untitled'),
+        content: z.string(),
+      }),
+      404: z.object({
+        message: z.string(),
+      }),
+    },
+  },
+  createPost: {
+    method: 'POST',
+    path: '/posts',
+    body: z.object({
+      title: z.string(),
+      content: z.string(),
+    }),
+    responses: {
+      201: z.object({
+        id: z.number(),
+        title: z.string(),
+        content: z.string(),
+      }),
+    },
+  },
+  uploadImage: {
+    method: 'POST',
+    path: '/images',
+    contentType: 'multipart/form-data',
+    body: c.body<{ image: File }>(),
+    responses: {
+      201: z.object({
+        id: z.number(),
+        url: z.string(),
+      }),
+    },
+  },
+  nested: {
+    getComments: {
+      method: 'GET',
+      path: '/posts/:id/comments',
+      pathParams: z.object({
+        id: z.string().transform((id) => Number(id)),
+      }),
+      responses: {
+        200: z.object({
+          comments: z.array(
+            z.object({
+              id: z.number(),
+              content: z.string(),
+            })
+          ),
+        }),
+        404: z.object({
+          message: z.string(),
+        }),
+      },
+    },
+  },
+});
+
+it('type inference helpers', () => {
+  type InferResponsesForServerTest = Expect<
+    Equal<
+      InferResponsesForServer<typeof contract>,
+      {
+        getPost:
+          | {
+              status: 200;
+              body: { title?: string | undefined; id: number; content: string };
+            }
+          | { status: 404; body: { message: string } }
+          | { status: Exclude<HTTPStatusCode, 200 | 404>; body: unknown };
+        createPost:
+          | {
+              status: 201;
+              body: { id: number; title: string; content: string };
+            }
+          | { status: Exclude<HTTPStatusCode, 201>; body: unknown };
+        uploadImage:
+          | {
+              status: 201;
+              body: { id: number; url: string };
+            }
+          | { status: Exclude<HTTPStatusCode, 201>; body: unknown };
+        nested: {
+          getComments:
+            | {
+                status: 200;
+                body: { comments: { id: number; content: string }[] };
+              }
+            | { status: 404; body: { message: string } }
+            | { status: Exclude<HTTPStatusCode, 200 | 404>; body: unknown };
+        };
+      }
+    >
+  >;
+
+  type InferResponsesForServerTest2 = Expect<
+    Equal<
+      InferResponsesForServer<typeof contract, 200>,
+      {
+        getPost: {
+          status: 200;
+          body: { title?: string | undefined; id: number; content: string };
+        };
+        createPost: {
+          status: 200;
+          body: unknown;
+        };
+        uploadImage: {
+          status: 200;
+          body: unknown;
+        };
+        nested: {
+          getComments: {
+            status: 200;
+            body: { comments: { id: number; content: string }[] };
+          };
+        };
+      }
+    >
+  >;
+
+  type InferResponsesForServerTest3 = Expect<
+    Equal<
+      InferResponsesForServer<typeof contract, 401>,
+      {
+        getPost: {
+          status: 401;
+          body: unknown;
+        };
+        createPost: {
+          status: 401;
+          body: unknown;
+        };
+        uploadImage: {
+          status: 401;
+          body: unknown;
+        };
+        nested: {
+          getComments: {
+            status: 401;
+            body: unknown;
+          };
+        };
+      }
+    >
+  >;
+
+  type InferResponsesForClientTest = Expect<
+    Equal<
+      InferResponsesForClient<typeof contract>,
+      {
+        getPost:
+          | {
+              status: 200;
+              body: { title: string; id: number; content: string };
+            }
+          | {
+              status: 404;
+              body: { message: string };
+            }
+          | { status: Exclude<HTTPStatusCode, 200 | 404>; body: unknown };
+        createPost:
+          | {
+              status: 201;
+              body: { id: number; title: string; content: string };
+            }
+          | { status: Exclude<HTTPStatusCode, 201>; body: unknown };
+        uploadImage:
+          | {
+              status: 201;
+              body: { id: number; url: string };
+            }
+          | { status: Exclude<HTTPStatusCode, 201>; body: unknown };
+        nested: {
+          getComments:
+            | {
+                status: 200;
+                body: { comments: { id: number; content: string }[] };
+              }
+            | { status: 404; body: { message: string } }
+            | { status: Exclude<HTTPStatusCode, 200 | 404>; body: unknown };
+        };
+      }
+    >
+  >;
+
+  type InferResponseBodyForServerTest = Expect<
+    Equal<
+      InferResponseBodyForServer<typeof contract.getPost, 200>,
+      { title?: string | undefined; id: number; content: string }
+    >
+  >;
+
+  type InferResponseBodyForClientTest = Expect<
+    Equal<
+      InferResponseBodyForClient<typeof contract.getPost, 200>,
+      { title: string; id: number; content: string }
+    >
+  >;
+
+  type InferRequestForServerTest = Expect<
+    Equal<
+      InferRequestForServer<typeof contract>,
+      {
+        getPost: {
+          query: { includeComments: boolean };
+          params: { id: number };
+        };
+        createPost: {
+          body: { title: string; content: string };
+        };
+        uploadImage: {
+          // eslint-disable-next-line @typescript-eslint/ban-types
+          body: {};
+        };
+        nested: {
+          getComments: {
+            params: { id: number };
+          };
+        };
+      }
+    >
+  >;
+
+  type InferRequestForClientTest = Expect<
+    Equal<
+      InferRequestForClient<typeof contract>,
+      {
+        getPost: {
+          query: { includeComments?: boolean | undefined };
+          params: { id: string };
+        };
+        createPost: {
+          body: { title: string; content: string };
+        };
+        uploadImage: {
+          body:
+            | {
+                image: File;
+              }
+            | FormData;
+        };
+        nested: {
+          getComments: {
+            params: { id: string };
+          };
+        };
+      }
+    >
+  >;
+});

--- a/libs/ts-rest/core/src/lib/infer-types.ts
+++ b/libs/ts-rest/core/src/lib/infer-types.ts
@@ -25,52 +25,41 @@ type AppRouteResponses<
       ? never
       : { status: Exclude<TStatus, keyof T['responses']>; body: unknown });
 
-export type InferResponsesForServer<
+export type ServerInferResponses<
   T extends AppRoute | AppRouter,
   TStatus extends HTTPStatusCode = HTTPStatusCode
 > = T extends AppRoute
   ? Prettify<AppRouteResponses<T, TStatus, 'server'>>
   : T extends AppRouter
-  ? {
-      [TKey in keyof T]: T[TKey] extends AppRoute
-        ? InferResponsesForServer<T[TKey], TStatus>
-        : T[TKey] extends AppRouter
-        ? InferResponsesForServer<T[TKey], TStatus>
-        : never;
-    }
+  ? { [TKey in keyof T]: ServerInferResponses<T[TKey], TStatus> }
   : never;
 
-export type InferResponsesForClient<
+export type ClientInferResponses<
   T extends AppRoute | AppRouter,
   TStatus extends HTTPStatusCode = HTTPStatusCode
 > = T extends AppRoute
   ? Prettify<AppRouteResponses<T, TStatus, 'client'>>
   : T extends AppRouter
-  ? {
-      [TKey in keyof T]: T[TKey] extends AppRoute
-        ? InferResponsesForClient<T[TKey], TStatus>
-        : T[TKey] extends AppRouter
-        ? InferResponsesForClient<T[TKey], TStatus>
-        : never;
-    }
+  ? { [TKey in keyof T]: ClientInferResponses<T[TKey], TStatus> }
   : never;
 
-export type InferResponseBodyForServer<
+export type ServerInferResponseBody<
   T extends AppRoute,
   TStatus extends keyof T['responses'] = keyof T['responses']
 > = Prettify<AppRouteResponses<T, TStatus & HTTPStatusCode, 'server'>['body']>;
 
-export type InferResponseBodyForClient<
+export type ClientInferResponseBody<
   T extends AppRoute,
   TStatus extends keyof T['responses'] = keyof T['responses']
 > = Prettify<AppRouteResponses<T, TStatus & HTTPStatusCode, 'client'>['body']>;
 
-type BodyWithoutFileIfMultiPart<T extends AppRouteMutation> =
+type BodyWithoutFileIfMultiPart<T extends AppRouteMutation> = Prettify<
   T['contentType'] extends 'multipart/form-data'
     ? Without<ZodInferOrType<T['body']>, File>
-    : ZodInferOrType<T['body']>;
+    : ZodInferOrType<T['body']>
+>;
 
-export type InferRequestForServer<T extends AppRoute | AppRouter> =
+export type ServerInferRequest<T extends AppRoute | AppRouter> =
   T extends AppRoute
     ? Prettify<
         Without<
@@ -87,16 +76,10 @@ export type InferRequestForServer<T extends AppRoute | AppRouter> =
         >
       >
     : T extends AppRouter
-    ? {
-        [TKey in keyof T]: T[TKey] extends AppRoute
-          ? InferRequestForServer<T[TKey]>
-          : T[TKey] extends AppRouter
-          ? InferRequestForServer<T[TKey]>
-          : never;
-      }
+    ? { [TKey in keyof T]: ServerInferRequest<T[TKey]> }
     : never;
 
-export type InferRequestForClient<T extends AppRoute | AppRouter> =
+export type ClientInferRequest<T extends AppRoute | AppRouter> =
   T extends AppRoute
     ? Prettify<
         Without<
@@ -118,11 +101,5 @@ export type InferRequestForClient<T extends AppRoute | AppRouter> =
         >
       >
     : T extends AppRouter
-    ? {
-        [TKey in keyof T]: T[TKey] extends AppRoute
-          ? InferRequestForClient<T[TKey]>
-          : T[TKey] extends AppRouter
-          ? InferRequestForClient<T[TKey]>
-          : never;
-      }
+    ? { [TKey in keyof T]: ClientInferRequest<T[TKey]> }
     : never;

--- a/libs/ts-rest/core/src/lib/infer-types.ts
+++ b/libs/ts-rest/core/src/lib/infer-types.ts
@@ -1,0 +1,128 @@
+import { AppRoute, AppRouteMutation, AppRouter } from './dsl';
+import { HTTPStatusCode } from './status-codes';
+import {
+  Prettify,
+  Without,
+  ZodInferOrType,
+  ZodInputOrType,
+} from './type-utils';
+import { PathParamsWithCustomValidators } from './client';
+
+type AppRouteResponses<
+  T extends AppRoute,
+  TStatus extends HTTPStatusCode,
+  TClientOrServer extends 'client' | 'server'
+> =
+  | {
+      [K in keyof T['responses'] & TStatus]: {
+        status: K;
+        body: TClientOrServer extends 'server'
+          ? ZodInputOrType<T['responses'][K]>
+          : ZodInferOrType<T['responses'][K]>;
+      };
+    }[keyof T['responses'] & TStatus]
+  | (Exclude<TStatus, keyof T['responses']> extends never
+      ? never
+      : { status: Exclude<TStatus, keyof T['responses']>; body: unknown });
+
+export type InferResponsesForServer<
+  T extends AppRoute | AppRouter,
+  TStatus extends HTTPStatusCode = HTTPStatusCode
+> = T extends AppRoute
+  ? Prettify<AppRouteResponses<T, TStatus, 'server'>>
+  : T extends AppRouter
+  ? {
+      [TKey in keyof T]: T[TKey] extends AppRoute
+        ? InferResponsesForServer<T[TKey], TStatus>
+        : T[TKey] extends AppRouter
+        ? InferResponsesForServer<T[TKey], TStatus>
+        : never;
+    }
+  : never;
+
+export type InferResponsesForClient<
+  T extends AppRoute | AppRouter,
+  TStatus extends HTTPStatusCode = HTTPStatusCode
+> = T extends AppRoute
+  ? Prettify<AppRouteResponses<T, TStatus, 'client'>>
+  : T extends AppRouter
+  ? {
+      [TKey in keyof T]: T[TKey] extends AppRoute
+        ? InferResponsesForClient<T[TKey], TStatus>
+        : T[TKey] extends AppRouter
+        ? InferResponsesForClient<T[TKey], TStatus>
+        : never;
+    }
+  : never;
+
+export type InferResponseBodyForServer<
+  T extends AppRoute,
+  TStatus extends keyof T['responses'] = keyof T['responses']
+> = Prettify<AppRouteResponses<T, TStatus & HTTPStatusCode, 'server'>['body']>;
+
+export type InferResponseBodyForClient<
+  T extends AppRoute,
+  TStatus extends keyof T['responses'] = keyof T['responses']
+> = Prettify<AppRouteResponses<T, TStatus & HTTPStatusCode, 'client'>['body']>;
+
+type BodyWithoutFileIfMultiPart<T extends AppRouteMutation> =
+  T['contentType'] extends 'multipart/form-data'
+    ? Without<ZodInferOrType<T['body']>, File>
+    : ZodInferOrType<T['body']>;
+
+export type InferRequestForServer<T extends AppRoute | AppRouter> =
+  T extends AppRoute
+    ? Prettify<
+        Without<
+          {
+            params: [undefined] extends PathParamsWithCustomValidators<T>
+              ? never
+              : Prettify<PathParamsWithCustomValidators<T>>;
+            body: T extends AppRouteMutation
+              ? BodyWithoutFileIfMultiPart<T>
+              : never;
+            query: 'query' extends keyof T ? ZodInferOrType<T['query']> : never;
+          },
+          never
+        >
+      >
+    : T extends AppRouter
+    ? {
+        [TKey in keyof T]: T[TKey] extends AppRoute
+          ? InferRequestForServer<T[TKey]>
+          : T[TKey] extends AppRouter
+          ? InferRequestForServer<T[TKey]>
+          : never;
+      }
+    : never;
+
+export type InferRequestForClient<T extends AppRoute | AppRouter> =
+  T extends AppRoute
+    ? Prettify<
+        Without<
+          {
+            params: [undefined] extends PathParamsWithCustomValidators<
+              T,
+              'client'
+            >
+              ? never
+              : Prettify<PathParamsWithCustomValidators<T, 'client'>>;
+            body: T extends AppRouteMutation
+              ? T['contentType'] extends 'multipart/form-data'
+                ? FormData | ZodInputOrType<T['body']>
+                : ZodInputOrType<T['body']>
+              : never;
+            query: 'query' extends keyof T ? ZodInputOrType<T['query']> : never;
+          },
+          never
+        >
+      >
+    : T extends AppRouter
+    ? {
+        [TKey in keyof T]: T[TKey] extends AppRoute
+          ? InferRequestForClient<T[TKey]>
+          : T[TKey] extends AppRouter
+          ? InferRequestForClient<T[TKey]>
+          : never;
+      }
+    : never;


### PR DESCRIPTION
Addressing the issues raised in #192 with the extra added benefit of being able to handle nested contracts.

Given some extra scrutiny, this code can be used to deduplicate a lot of code in the client libraries and also the server libraries.