### PR TITLE
Add rawBody and contentType to Custom Client API arguments

### DIFF
--- a/apps/docs/docs/core/custom.md
+++ b/apps/docs/docs/core/custom.md
@@ -44,22 +44,6 @@ const client = initQueryClient(postsApi, {
 });
 ```
 
-### Accessing the raw body and content type
-
-Ts-Rest automatically stringifies your `body` input for mutations. You can access the raw body object and content-type like so:
-
-```typescript
-const client = initQueryClient(postsApi, {
-  baseUrl: 'http://localhost:5003',
-  baseHeaders: {},
-  api: async ({ path, method, headers, body, rawBody, contentType }) => {
-    // do something with rawBody ✨
-    return tsRestFetchApi(args);
-  },
-});
-```
-
-
 The magical bit, is this is now fully typed and will work with your IDE's autocomplete! 🤯
 
 One note here, any extra args which are provided here but aren't typed correctly - e.g. if you've `@ts-expect-error`'d, **will still be passed to your api**. This is because the `args` parameter is a spread of all the other arguments you pass in to your api.
@@ -75,6 +59,21 @@ client.getPosts({
 :::tip
 You can use this to accomplish loads of patterns, such as adding a `cache` argument to your api, or adding a `logger` argument to your api - maybe you want to add an `onUploadProgress` argument to your api to track upload progress? You can do all of this with the `args` parameter!
 :::
+
+### Accessing the raw body and content type
+
+Ts-Rest automatically stringifies your `body` input for mutations. You can access the raw body object and content-type like so:
+
+```typescript
+const client = initQueryClient(postsApi, {
+  baseUrl: 'http://localhost:5003',
+  baseHeaders: {},
+  api: async ({ path, method, headers, body, rawBody, contentType }) => {
+    // do something with rawBody ✨
+    return tsRestFetchApi(args);
+  },
+});
+```
 
 ## Using Axios (custom api override)
 

--- a/apps/docs/docs/core/custom.md
+++ b/apps/docs/docs/core/custom.md
@@ -46,7 +46,7 @@ const client = initQueryClient(postsApi, {
 
 ### Accessing the raw body and content type
 
-Our client automatically stringifies your `body` input for mutations. You can access the raw body object and content-type like so:
+Ts-Rest automatically stringifies your `body` input for mutations. You can access the raw body object and content-type like so:
 
 ```typescript
 const client = initQueryClient(postsApi, {

--- a/apps/docs/docs/core/custom.md
+++ b/apps/docs/docs/core/custom.md
@@ -44,6 +44,22 @@ const client = initQueryClient(postsApi, {
 });
 ```
 
+### Accessing the raw body and content type
+
+Our client automatically stringifies your `body` input for mutations. You can access the raw body object and content-type like so:
+
+```typescript
+const client = initQueryClient(postsApi, {
+  baseUrl: 'http://localhost:5003',
+  baseHeaders: {},
+  api: async ({ path, method, headers, body, rawBody, contentType }) => {
+    // do something with rawBody ✨
+    return tsRestFetchApi(args);
+  },
+});
+```
+
+
 The magical bit, is this is now fully typed and will work with your IDE's autocomplete! 🤯
 
 One note here, any extra args which are provided here but aren't typed correctly - e.g. if you've `@ts-expect-error`'d, **will still be passed to your api**. This is because the `args` parameter is a spread of all the other arguments you pass in to your api.

--- a/apps/example-next/tests/react-query.spec.tsx
+++ b/apps/example-next/tests/react-query.spec.tsx
@@ -377,6 +377,13 @@ describe('react-query', () => {
       headers: {
         'content-type': 'application/json',
       },
+      rawBody: {
+        authorId: '1',
+        content: '',
+        description: 'test',
+        title: 'test',
+      },
+      contentType: undefined,
     });
 
     await waitFor(() => {

--- a/apps/example-next/tests/react-query.spec.tsx
+++ b/apps/example-next/tests/react-query.spec.tsx
@@ -383,7 +383,7 @@ describe('react-query', () => {
         description: 'test',
         title: 'test',
       },
-      contentType: undefined,
+      contentType: 'application/json',
     });
 
     await waitFor(() => {

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -145,6 +145,8 @@ export type ApiFetcherArgs = {
   method: string;
   headers: Record<string, string>;
   body: FormData | string | null | undefined;
+  rawBody: unknown;
+  contentType:  AppRouteMutation['contentType']
   credentials?: RequestCredentials;
 };
 
@@ -236,6 +238,8 @@ export const fetchApi = ({
       credentials: clientArgs.credentials,
       headers: combinedHeaders,
       body: body instanceof FormData ? body : createFormData(body),
+      rawBody: body,
+      contentType: route.contentType,
       ...extraInputArgs,
     });
   }
@@ -250,6 +254,8 @@ export const fetchApi = ({
     },
     body:
       body !== null && body !== undefined ? JSON.stringify(body) : undefined,
+    rawBody: body,
+    contentType: route.method !== 'GET'  ? route.contentType : undefined,
     ...extraInputArgs,
   });
 };

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -239,7 +239,7 @@ export const fetchApi = ({
       headers: combinedHeaders,
       body: body instanceof FormData ? body : createFormData(body),
       rawBody: body,
-      contentType: route.contentType,
+      contentType: 'multipart/form-data',
       ...extraInputArgs,
     });
   }
@@ -255,7 +255,7 @@ export const fetchApi = ({
     body:
       body !== null && body !== undefined ? JSON.stringify(body) : undefined,
     rawBody: body,
-    contentType: route.method !== 'GET'  ? route.contentType : undefined,
+    contentType: route.method !== 'GET'  ? 'application/json' : undefined,
     ...extraInputArgs,
   });
 };


### PR DESCRIPTION
This aims to partially fix #198. 

My coworker discovered this issue when working with API Gateway/AWS Amplify. We have to do the following custom logic when using a Custom Client:

```typescript
// Convert body back to JSON before sending. Right now ts-rest will always stringify the body.
// This causes issue when deployed with API Gateway as API Gateway will also stringify the body.
result = await this.api.post(appConfig.APP_BASENAME, path, { body: JSON.parse(body as string), response: true })
```

The above means the ts-rest custom client stringifies the body, and then we have to _parse_ that stringified body for it to be _re-stringified_ again. This is a big no-no when it comes to performance. 

This PR adds `rawBody` and `contentType` to the params passed to the Custom Client. I know we can use the `extraInputArgs` feature. However, I think developers should have more guidance when developing Custom Clients, and adding these extra runtime params/types should help. 

Eventually, developers _should_ be able to opt out of that extra `JSON.stringify` operation if they need to for performance reasons. 

These are simply additions so that we do not introduce any breaking changes. In 4.0 we should revisit the implementation of this section of code. 
