### PR TITLE
fix: compatibility with Node.js TS native ES modules

### DIFF
--- a/.changeset/moody-years-fail.md
+++ b/.changeset/moody-years-fail.md
@@ -1,0 +1,11 @@
+---
+'@ts-rest/core': patch
+'@ts-rest/express': patch
+'@ts-rest/nest': patch
+'@ts-rest/next': patch
+'@ts-rest/open-api': patch
+'@ts-rest/react-query': patch
+'@ts-rest/solid-query': patch
+---
+
+Fix comptability with Node.js TS native ESM code

--- a/libs/ts-rest/core/project.json
+++ b/libs/ts-rest/core/project.json
@@ -15,7 +15,8 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true
+        "generateExportsField": true,
+        "skipTypeField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/express/project.json
+++ b/libs/ts-rest/express/project.json
@@ -15,7 +15,8 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true
+        "generateExportsField": true,
+        "skipTypeField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/nest/project.json
+++ b/libs/ts-rest/nest/project.json
@@ -15,7 +15,8 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true
+        "generateExportsField": true,
+        "skipTypeField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/next/project.json
+++ b/libs/ts-rest/next/project.json
@@ -15,7 +15,8 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true
+        "generateExportsField": true,
+        "skipTypeField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/open-api/project.json
+++ b/libs/ts-rest/open-api/project.json
@@ -15,7 +15,8 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true
+        "generateExportsField": true,
+        "skipTypeField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/react-query/project.json
+++ b/libs/ts-rest/react-query/project.json
@@ -16,7 +16,8 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true
+        "generateExportsField": true,
+        "skipTypeField": true
       }
     },
     "lint": {

--- a/libs/ts-rest/solid-query/project.json
+++ b/libs/ts-rest/solid-query/project.json
@@ -16,7 +16,8 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true
+        "generateExportsField": true,
+        "skipTypeField": true
       }
     },
     "lint": {


### PR DESCRIPTION
Fixes #188 

NX was adding `"type": "module"` to the compiled package.json files because we compile `esm` format JS files. This package.json field makes the Typescript compiler of consuming code think that ts-rest libraries are native ES modules, which in fact they are not. We compile both ESM and CJS JS files, but the compiled .d.ts files are in CJS format only, so it needs to be indicated correctly which format the project originally is, so Typescript knows how to transpile our definition files.