### PR TITLE
Revert "fix: compatibility with Node.js TS native ES modules (#200)"

### DIFF
--- a/.changeset/hip-suns-occur.md
+++ b/.changeset/hip-suns-occur.md
@@ -1,0 +1,11 @@
+---
+'@ts-rest/core': patch
+'@ts-rest/express': patch
+'@ts-rest/nest': patch
+'@ts-rest/next': patch
+'@ts-rest/open-api': patch
+'@ts-rest/react-query': patch
+'@ts-rest/solid-query': patch
+---
+
+Revert ESM fix, due to failed compilation on Next.js

--- a/libs/ts-rest/core/project.json
+++ b/libs/ts-rest/core/project.json
@@ -15,8 +15,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/express/project.json
+++ b/libs/ts-rest/express/project.json
@@ -15,8 +15,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/nest/project.json
+++ b/libs/ts-rest/nest/project.json
@@ -15,8 +15,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/next/project.json
+++ b/libs/ts-rest/next/project.json
@@ -15,8 +15,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/open-api/project.json
+++ b/libs/ts-rest/open-api/project.json
@@ -15,8 +15,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/react-query/project.json
+++ b/libs/ts-rest/react-query/project.json
@@ -16,8 +16,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "lint": {

--- a/libs/ts-rest/solid-query/project.json
+++ b/libs/ts-rest/solid-query/project.json
@@ -16,8 +16,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "lint": {


### PR DESCRIPTION
This reverts commit ecac73d169a8c812501c002dde6e4c780077aeae.

The previous fix broke react-query causing `No QueryClient set, use QueryClientProvider to set one` errors on compilation. This is caused by different versions of `@tanstack/react-query` being used.

In this case, it was because Next.js was using the ESM version of react-query but ts-rest was using the CJS version. Next.js will include the ESM version of any library only if package.json contains `"module": "type"` or the file extension of the entry file inside the `exports` field is `.mjs` and uses `.mjs` for all imports. We still need a `.js` ESM file for older node versions that do not use the `exports` field or `.mjs` extension.

We should have something like this in package.json

```json
  "types": "./index.d.ts",
  "main": "./index.js", // CJS
  "module": "./index.esm.js", // old style ESM
  "exports": {
    ".": {
      "types": "./index.d.ts",
      "import": "./index.mjs", // new style ESM for next.js, etc.
      "require": "./index.js"
    }
  },
```

At the moment, there is no obvious way of doing this directly with the nx tooling, so we'll have to roll our own to fix native Node16 ESM compatibility again. So for now we have to keep using `"type": "module"` in order for Next.js to use the ESM version of ts-rest.