### PR TITLE
Filter out undefined values from json queries

### DIFF
--- a/.changeset/pretty-cows-shave.md
+++ b/.changeset/pretty-cows-shave.md
@@ -1,0 +1,5 @@
+---
+"@ts-rest/core": patch
+---
+
+Filter out undefined values from json queries

--- a/libs/ts-rest/core/src/lib/query.spec.ts
+++ b/libs/ts-rest/core/src/lib/query.spec.ts
@@ -233,6 +233,7 @@ describe('encodeQueryParamsJson', () => {
       numberString: '123',
       boolean: true,
       null: null,
+      undefined: undefined,
       sorting: {
         by: 'date',
         order: 'asc',

--- a/libs/ts-rest/core/src/lib/query.ts
+++ b/libs/ts-rest/core/src/lib/query.ts
@@ -17,6 +17,7 @@ export const encodeQueryParamsJson = (query: unknown) => {
   }
 
   return Object.entries(query)
+    .filter(([, value]) => value !== undefined)
     .map(([key, value]) => {
       let encodedValue;
 
@@ -29,15 +30,12 @@ export const encodeQueryParamsJson = (query: unknown) => {
         isNaN(Number(value))
       ) {
         encodedValue = value;
-      } else if (value === undefined) {
-        return;
       } else {
         encodedValue = JSON.stringify(value);
       }
 
       return `${encodeURIComponent(key)}=${encodeURIComponent(encodedValue)}`;
     })
-    .filter((maybeStr): maybeStr is string => typeof maybeStr === 'string')
     .join('&');
 };
 

--- a/libs/ts-rest/core/src/lib/query.ts
+++ b/libs/ts-rest/core/src/lib/query.ts
@@ -29,12 +29,15 @@ export const encodeQueryParamsJson = (query: unknown) => {
         isNaN(Number(value))
       ) {
         encodedValue = value;
+      } else if (value === undefined) {
+        return;
       } else {
         encodedValue = JSON.stringify(value);
       }
 
       return `${encodeURIComponent(key)}=${encodeURIComponent(encodedValue)}`;
     })
+    .filter((maybeStr): maybeStr is string => typeof maybeStr === 'string')
     .join('&');
 };
 


### PR DESCRIPTION
If undefined values are present they are converted into the string `undefined`. This is not a valid JSON value so it fails parsing at [parseJsonQueryObject](https://github.com/ts-rest/ts-rest/blob/8011ec7c3cf098570d9f266a4f4cde4a36e38f82/libs/ts-rest/core/src/lib/query.ts#L104).

Filtering it out on the client side means that it will still have the value of undefined on the server.


P.S Thanks for a great library!!