### PR TITLE
feat: OpenAPI support Zod Refine

### DIFF
--- a/.changeset/stupid-donkeys-flash.md
+++ b/.changeset/stupid-donkeys-flash.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/open-api': patch
+---
+
+Add missing support for Zod Refine

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
@@ -492,5 +492,115 @@ describe('ts-rest-open-api', () => {
         )
       ).toThrowError(/getPost/);
     });
+
+    it('works with zod refine', () => {
+      const routerWithRefine = c.router({
+        endpointWithZodRefine: {
+          method: 'GET',
+          path: '/refine',
+          responses: {
+            200: c.response<null>(),
+          },
+          query: z
+            .object({
+              foo: z.string(),
+            })
+            .refine((v) => v.foo === 'bar', {
+              message: 'foo must be bar',
+            }),
+        },
+      });
+
+      const schema = generateOpenApi(routerWithRefine, {
+        info: { title: 'Blog API', version: '0.1' },
+      });
+
+      expect(schema).toEqual({
+        info: {
+          title: 'Blog API',
+          version: '0.1',
+        },
+        openapi: '3.0.2',
+        paths: {
+          '/refine': {
+            get: {
+              deprecated: undefined,
+              description: undefined,
+              parameters: [
+                {
+                  in: 'query',
+                  name: 'foo',
+                  required: true,
+                  schema: {
+                    type: 'string',
+                  },
+                },
+              ],
+              responses: {
+                '200': {
+                  description: '200',
+                },
+              },
+              summary: undefined,
+              tags: [],
+            },
+          },
+        },
+      });
+    });
+
+    it('works with zod transform', () => {
+      const routerWithTransform = c.router({
+        endpointWithZodTransform: {
+          method: 'GET',
+          path: '/transform',
+          responses: {
+            200: c.response<null>(),
+          },
+          query: z
+            .object({
+              foo: z.string(),
+            })
+            .transform((v) => ({ fooTransformed: v.foo })),
+        },
+      });
+
+      const schema = generateOpenApi(routerWithTransform, {
+        info: { title: 'Blog API', version: '0.1' },
+      });
+
+      expect(schema).toEqual({
+        info: {
+          title: 'Blog API',
+          version: '0.1',
+        },
+        openapi: '3.0.2',
+        paths: {
+          '/transform': {
+            get: {
+              deprecated: undefined,
+              description: undefined,
+              parameters: [
+                {
+                  in: 'query',
+                  name: 'foo',
+                  required: true,
+                  schema: {
+                    type: 'string',
+                  },
+                },
+              ],
+              responses: {
+                '200': {
+                  description: '200',
+                },
+              },
+              summary: undefined,
+              tags: [],
+            },
+          },
+        },
+      });
+    });
   });
 });

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
@@ -94,11 +94,16 @@ const getQueryParametersFromZod = (zodObject: unknown, jsonQuery = false) => {
     return [];
   }
 
-  let zodShape = zodObject.shape;
+  let zodShape;
 
-  if (zodObject instanceof z.ZodEffects) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    zodShape = (zodObject as z.ZodEffects<any>)._def.schema.shape;
+  if ('shape' in zodObject) {
+    zodShape = zodObject.shape;
+    // @ts-expect-error - Support ZodEffects
+  } else if ('schema' in zodObject._def) {
+    // @ts-expect-error - Support ZodEffects
+    zodShape = zodObject._def.schema.shape;
+  } else {
+    throw new Error('Unknown zod object type');
   }
 
   return Object.entries(zodShape).map(([key, value]) => {

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
@@ -94,7 +94,14 @@ const getQueryParametersFromZod = (zodObject: unknown, jsonQuery = false) => {
     return [];
   }
 
-  return Object.entries(zodObject.shape).map(([key, value]) => {
+  let zodShape = zodObject.shape;
+
+  if (zodObject instanceof z.ZodEffects) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    zodShape = (zodObject as z.ZodEffects<any>)._def.schema.shape;
+  }
+
+  return Object.entries(zodShape).map(([key, value]) => {
     const schema = getOpenApiSchemaFromZod(value)!;
     const isObject = (value as z.ZodTypeAny)._def.typeName === 'ZodObject';
     const isRequired = !(value as z.ZodTypeAny).isOptional();


### PR DESCRIPTION
This was missing and threw and error if you tried to instantiate a schema with a refined object at the top level!