### PR TITLE
Implement strict mode to throw on unexpected responses

### DIFF
--- a/.changeset/wise-pumas-kick.md
+++ b/.changeset/wise-pumas-kick.md
@@ -1,0 +1,5 @@
+---
+"@ts-rest/core": minor
+---
+
+Add `throwOnUnknownStatus` to `initClient` configuration. When set to `true` the client will throw errors for all status codes returned by the server which are not defined in the contract.

--- a/libs/ts-rest/core/src/index.ts
+++ b/libs/ts-rest/core/src/index.ts
@@ -8,3 +8,4 @@ export * from './lib/zod-utils';
 export * from './lib/server';
 export * from './lib/response-validation-error';
 export * from './lib/infer-types';
+export * from './lib/unknown-status-error';

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -691,4 +691,29 @@ describe('custom api', () => {
       })
     );
   });
+
+  it('has correct types when throwOnUnexpectedResponse is configured', async () => {
+    const client = initClient(router, {
+      baseUrl: 'https://api.com',
+      baseHeaders: {
+        'X-Api-Key': 'foo',
+      },
+      throwOnUnexpectedResponse: true,
+    });
+
+    fetchMock.getOnce(
+      {
+        url: 'https://api.com/posts',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+      { status: 200 }
+    );
+
+    const result = await client.posts.getPosts({});
+
+    // @ts-expect-error 404 is not defined in the known responses
+    result.status === 404;
+  });
 });

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -692,13 +692,13 @@ describe('custom api', () => {
     );
   });
 
-  it('has correct types when strict is configured', async () => {
+  it('has correct types when throwOnUnknownStatus is configured', async () => {
     const client = initClient(router, {
       baseUrl: 'https://api.com',
       baseHeaders: {
         'X-Api-Key': 'foo',
       },
-      strict: true,
+      throwOnUnknownStatus: true,
     });
 
     fetchMock.getOnce({ url: 'https://api.com/posts' }, { status: 200 });
@@ -709,13 +709,13 @@ describe('custom api', () => {
     result.status === 404;
   });
 
-  it('throws an error when strict is configured and response is unknown', async () => {
+  it('throws an error when throwOnUnknownStatus is configured and response is unknown', async () => {
     const client = initClient(router, {
       baseUrl: 'https://isolated.com',
       baseHeaders: {
         'X-Api-Key': 'foo',
       },
-      strict: true,
+      throwOnUnknownStatus: true,
     });
 
     fetchMock.getOnce({ url: 'https://isolated.com/posts' }, { status: 419 });

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -705,8 +705,9 @@ describe('custom api', () => {
 
     const result = await client.posts.getPosts({});
 
-    // @ts-expect-error 404 is not defined in the known responses
-    result.status === 404;
+    type ClientGetPostsResponseStatusType = Expect<
+      Equal<typeof result.status, 200>
+    >;
   });
 
   it('throws an error when throwOnUnknownStatus is configured and response is unknown', async () => {

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -177,11 +177,6 @@ export interface ClientArgs {
   api?: ApiFetcher;
   credentials?: RequestCredentials;
   jsonQuery?: boolean;
-  /**
-   * Ensures that the responses from the server match those defined in the
-   * contract.
-   */
-  throwOnUnknownStatus?: boolean;
 }
 
 export type ApiFetcherArgs = {
@@ -329,7 +324,7 @@ export const getCompleteUrl = (
 
 export const getRouteQuery = <TAppRoute extends AppRoute>(
   route: TAppRoute,
-  clientArgs: ClientArgs
+  clientArgs: InitClientArgs
 ) => {
   const knownResponseStatuses = Object.keys(route.responses);
   return async (inputArgs?: DataReturnArgsBase<any, ClientArgs>) => {
@@ -378,7 +373,18 @@ export type InitClientReturnNoUnknownStatus<
   TClientArgs extends ClientArgs & { throwOnUnknownStatus: true }
 > = RecursiveProxyObjNoUnknownStatus<T, TClientArgs>;
 
-export const initClient = <T extends AppRouter, TClientArgs extends ClientArgs>(
+export type InitClientArgs = ClientArgs & {
+  /**
+   * Ensures that the responses from the server match those defined in the
+   * contract.
+   */
+  throwOnUnknownStatus?: boolean;
+};
+
+export const initClient = <
+  T extends AppRouter,
+  TClientArgs extends InitClientArgs
+>(
   router: T,
   args: TClientArgs
 ): TClientArgs extends { throwOnUnknownStatus: true }

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -13,6 +13,7 @@ import {
   ZodInferOrType,
   ZodInputOrType,
 } from './type-utils';
+import { UnknownStatusError } from './unknown-status-error';
 
 type RecursiveProxyObj<T extends AppRouter, TClientArgs extends ClientArgs> = {
   [TKey in keyof T]: T[TKey] extends AppRoute
@@ -363,11 +364,7 @@ export const getRouteQuery = <TAppRoute extends AppRoute>(
     if (knownResponseStatuses.includes(response.status.toString())) {
       return response;
     }
-    throw new Error(
-      `Server returned unexpected response. Expected one of: ${knownResponseStatuses.join(
-        ','
-      )} got: ${response.status}`
-    );
+    throw new UnknownStatusError(response, knownResponseStatuses);
   };
 };
 

--- a/libs/ts-rest/core/src/lib/unknown-status-error.ts
+++ b/libs/ts-rest/core/src/lib/unknown-status-error.ts
@@ -1,0 +1,15 @@
+export class UnknownStatusError extends Error {
+  response: { status: number; body: unknown };
+
+  constructor(
+    response: { status: number; body: unknown },
+    knownResponseStatuses: string[]
+  ) {
+    const expectedStatuses = knownResponseStatuses.join(',');
+    super(
+      `Server returned unexpected response. Expected one of: ${expectedStatuses} got: ${response.status}`
+    );
+
+    this.response = response;
+  }
+}


### PR DESCRIPTION
Resolves #220


This PR adds a `strict` mode to the client which causes the client to throw errors for any HTTP status returned by the server  which is not defined in the contract.