### PR TITLE
chore: use aggregate release for all packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    outputs:
-      nx_affected: ${{ steps.set-nx-affected.outputs.nx_affected }}
     permissions:
       actions: read
       contents: write
@@ -19,15 +17,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Set NX Shas
-        uses: nrwl/nx-set-shas@177b48373c6dc583ce0d9257ffb484bdd232fedf
-        with:
-          main-branch-name: 'main'
-      - name: NX Shas
-        run: |
-          echo "BASE: ${{ env.NX_BASE }}"
-          echo "HEAD: ${{ env.NX_HEAD }}"
 
       - name: Install pnpm
         uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd
@@ -52,64 +41,26 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Modify Workspace File
+      - name: Modify "workspaces" value in package.json
         run: sed -e "s;libs/ts-rest/\*;dist/libs/ts-rest/*;g" package.json > package-new.json && mv package-new.json package.json
 
+      - name: Get Release Version
+        id: release-version
+        uses: martinbeentjes/npm-get-version-action@3cf273023a0dda27efcd3164bdfb51908dd46a5b
+        with:
+          path: libs/ts-rest/core
+
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@d89c1de63c7f28ac47ec85ed395f5f1d045d4697
+        uses: dotansimha/changesets-action@069996e9be15531bd598272996fa23853d61590e
         with:
           title: Release Tracking
           # this expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: pnpm release
           version: pnpm version-packages
-          createGithubReleases: true
+          createGithubReleases: aggregate
+          githubReleaseName: v${{ steps.release-version.outputs.current-version }}
+          githubTagName: v${{ steps.release-version.outputs.current-version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Run CI on affected
-        run: pnpm run ci:nx-affected
-
-  # deploy-docs:
-  #   name: Deploy Docs
-  #   runs-on: ubuntu-latest
-  #   needs: [build]
-  #   if: ${{ contains(needs.build.outputs.nx_affected, 'docs') }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - uses: nrwl/nx-set-shas@v2
-
-  #     - uses: pnpm/action-setup@v2.0.1
-  #       name: Install pnpm
-  #       id: pnpm-install
-  #       with:
-  #         version: 7
-  #         run_install: false
-
-  #     - name: Get pnpm store directory
-  #       id: pnpm-cache
-  #       run: |
-  #         echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
-
-  #     - uses: actions/cache@v3
-  #       name: Setup pnpm cache
-  #       with:
-  #         path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-  #         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-pnpm-store-
-
-  #     - name: Install dependencies
-  #       run: pnpm install
-  #     - name: Build Docs
-  #       run: pnpm exec nx run docs:build
-  #     - name: Set AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: eu-west-2
-  #     - name: 'Deploy docs to S3'
-  #       run: 'aws s3 sync dist/apps/docs/ s3://ts-rest-docs-bucket/'

--- a/libs/ts-rest/core/project.json
+++ b/libs/ts-rest/core/project.json
@@ -12,6 +12,18 @@
         "outputPath": "dist/libs/ts-rest/core",
         "main": "libs/ts-rest/core/src/index.ts",
         "tsConfig": "libs/ts-rest/core/tsconfig.lib.json",
+        "assets": [
+          {
+            "glob": "CHANGELOG.md",
+            "input": "libs/ts-rest/core",
+            "output": "."
+          },
+          {
+            "glob": "README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",

--- a/libs/ts-rest/express/project.json
+++ b/libs/ts-rest/express/project.json
@@ -12,6 +12,18 @@
         "outputPath": "dist/libs/ts-rest/express",
         "main": "libs/ts-rest/express/src/index.ts",
         "tsConfig": "libs/ts-rest/express/tsconfig.lib.json",
+        "assets": [
+          {
+            "glob": "CHANGELOG.md",
+            "input": "libs/ts-rest/express",
+            "output": "."
+          },
+          {
+            "glob": "README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",

--- a/libs/ts-rest/nest/project.json
+++ b/libs/ts-rest/nest/project.json
@@ -12,6 +12,18 @@
         "outputPath": "dist/libs/ts-rest/nest",
         "main": "libs/ts-rest/nest/src/index.ts",
         "tsConfig": "libs/ts-rest/nest/tsconfig.lib.json",
+        "assets": [
+          {
+            "glob": "CHANGELOG.md",
+            "input": "libs/ts-rest/nest",
+            "output": "."
+          },
+          {
+            "glob": "README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",

--- a/libs/ts-rest/next/project.json
+++ b/libs/ts-rest/next/project.json
@@ -12,6 +12,18 @@
         "outputPath": "dist/libs/ts-rest/next",
         "main": "libs/ts-rest/next/src/index.ts",
         "tsConfig": "libs/ts-rest/next/tsconfig.lib.json",
+        "assets": [
+          {
+            "glob": "CHANGELOG.md",
+            "input": "libs/ts-rest/next",
+            "output": "."
+          },
+          {
+            "glob": "README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",

--- a/libs/ts-rest/open-api/project.json
+++ b/libs/ts-rest/open-api/project.json
@@ -12,6 +12,18 @@
         "outputPath": "dist/libs/ts-rest/open-api",
         "main": "libs/ts-rest/open-api/src/index.ts",
         "tsConfig": "libs/ts-rest/open-api/tsconfig.lib.json",
+        "assets": [
+          {
+            "glob": "CHANGELOG.md",
+            "input": "libs/ts-rest/open-api",
+            "output": "."
+          },
+          {
+            "glob": "README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",

--- a/libs/ts-rest/react-query/project.json
+++ b/libs/ts-rest/react-query/project.json
@@ -13,6 +13,18 @@
         "outputPath": "dist/libs/ts-rest/react-query",
         "main": "libs/ts-rest/react-query/src/index.ts",
         "tsConfig": "libs/ts-rest/react-query/tsconfig.lib.json",
+        "assets": [
+          {
+            "glob": "CHANGELOG.md",
+            "input": "libs/ts-rest/react-query",
+            "output": "."
+          },
+          {
+            "glob": "README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",

--- a/libs/ts-rest/solid-query/project.json
+++ b/libs/ts-rest/solid-query/project.json
@@ -13,6 +13,18 @@
         "outputPath": "dist/libs/ts-rest/solid-query",
         "main": "libs/ts-rest/solid-query/src/index.ts",
         "tsConfig": "libs/ts-rest/solid-query/tsconfig.lib.json",
+        "assets": [
+          {
+            "glob": "CHANGELOG.md",
+            "input": "libs/ts-rest/solid-query",
+            "output": "."
+          },
+          {
+            "glob": "README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "license": "MIT",
   "scripts": {
     "version-packages": "changeset version",
-    "release": "pnpm nx run-many --target=build --exclude=example-expo && pnpm fix-esm && pnpm copy-readme && changeset tag && changeset publish",
-    "copy-readme": "find dist/libs/ts-rest -mindepth 1 -maxdepth 1 -type d -exec cp README.md '{}' ';'",
+    "release": "pnpm nx run-many --target=build --exclude=example-expo && pnpm fix-esm && changeset publish",
     "fix-esm": "node tools/scripts/fix-esm.mjs",
     "nest": "pnpm nx run example-nest:serve",
     "affected:all": "pnpm nx affected:lint && pnpm nx affected:test && pnpm nx affected:build",


### PR DESCRIPTION
Using the "dotansimha/changesets-action" fork of "changesets/action" which allows us to create a single release for all packages together. Should be better than creating a release per package. Separate tags per package will still be created. This might fix the problem with releases not being created. 

Also cleaned up anything that has to do with `nx_affected` in the release since that was only used previously to determine whether to release docs or not. Vercel now takes care of that, so it is not needed.