### PR TITLE
feat: exposed response headers to clients

### DIFF
--- a/.changeset/happy-hairs-press.md
+++ b/.changeset/happy-hairs-press.md
@@ -1,0 +1,7 @@
+---
+'@ts-rest/react-query': minor
+'@ts-rest/solid-query': minor
+'@ts-rest/core': minor
+---
+
+Response headers are now exposed to clients. Users of custom API fetchers should start returning headers.

--- a/apps/docs/docs/core/custom.md
+++ b/apps/docs/docs/core/custom.md
@@ -108,12 +108,12 @@ const client = initClient(contract, {
         headers,
         data: body,
       });
-      return { status: result.status, body: result.data };
+      return { status: result.status, body: result.data, headers: response.headers };
     } catch (e: Error | AxiosError | any) {
       if (isAxiosError(e)) {
         const error = e as AxiosError;
         const response = error.response as AxiosResponse;
-        return { status: response.status, body: response.data };
+        return { status: response.status, body: response.data, headers: response.headers };
       }
       throw e;
     }
@@ -150,12 +150,12 @@ export class SampleAPI {
             headers,
             data: body,
           });
-          return { status: result.status, body: result.data };
+          return { status: result.status, body: result.data, headers: response.headers };
         } catch (e: Error | AxiosError | any) {
           if (isAxiosError(e)) {
             const error = e as AxiosError;
             const response = error.response as AxiosResponse;
-            return { status: response.status, body: response.data };
+            return { status: response.status, body: response.data, headers: response.headers };
           }
           throw e;
         }
@@ -195,12 +195,12 @@ export class SampleAPI {
             },
             data: body,
           });
-          return { status: result.status, body: result.data };
+          return { status: result.status, body: result.data, headers: result.headers };
         } catch (e: Error | AxiosError | any) {
           if (isAxiosError(e)) {
             const error = e as AxiosError;
             const response = error.response as AxiosResponse;
-            return { status: response.status, body: response.data };
+            return { status: response.status, body: response.data, headers: result.headers };
           }
           throw e;
         }

--- a/apps/docs/docs/core/fetch.md
+++ b/apps/docs/docs/core/fetch.md
@@ -81,13 +81,16 @@ The `data` property is typed as follows:
 ```typescript
 const data: {
     status: 200;
-    body: User
+    body: User;
+    headers: Record<string, string>
 } | {
     status: 400 | 100 | 101 | 102 | 201 | 202 | 203 | 204 | 205 | 206 | 207 | 300 | 301 | 302 | 303 | 304 | 305 | 307 | ... 36 more ... | 511;
     body: unknown;
+    headers: Record<string, string>
 }
 ```
 
+In this context, the term 'headers' refers to the response headers retrieved either from the default Fetch client or a custom client implementation.
 :::
 
 ## Credentials (sending cookies)
@@ -131,9 +134,7 @@ Objects implementing `.toJSON()` will irreversibly be converted to JSON, so you 
 For example, Date objects will be converted ISO strings by default, so you could handle this case like so:
 
 ```typescript
-const dateSchema = z
-  .union([z.string().datetime(), z.date()])
-  .transform((date) => (typeof date === 'string' ? new Date(date) : date));
+const dateSchema = z.union([z.string().datetime(), z.date()]).transform((date) => (typeof date === 'string' ? new Date(date) : date));
 ```
 
 This will ensure that you could pass Date objects in your client queries. They will be converted to ISO strings in the JSON-encoded URL query string, and then converted back to Date objects on the server by zod's parser.

--- a/apps/docs/docs/core/fetch.md
+++ b/apps/docs/docs/core/fetch.md
@@ -134,7 +134,9 @@ Objects implementing `.toJSON()` will irreversibly be converted to JSON, so you 
 For example, Date objects will be converted ISO strings by default, so you could handle this case like so:
 
 ```typescript
-const dateSchema = z.union([z.string().datetime(), z.date()]).transform((date) => (typeof date === 'string' ? new Date(date) : date));
+const dateSchema = z
+  .union([z.string().datetime(), z.date()])
+  .transform((date) => (typeof date === 'string' ? new Date(date) : date));
 ```
 
 This will ensure that you could pass Date objects in your client queries. They will be converted to ISO strings in the JSON-encoded URL query string, and then converted back to Date objects on the server by zod's parser.

--- a/apps/docs/docs/core/fetch.md
+++ b/apps/docs/docs/core/fetch.md
@@ -82,11 +82,11 @@ The `data` property is typed as follows:
 const data: {
     status: 200;
     body: User;
-    headers: Record<string, string>
+    headers: Headers
 } | {
     status: 400 | 100 | 101 | 102 | 201 | 202 | 203 | 204 | 205 | 206 | 207 | 300 | 301 | 302 | 303 | 304 | 305 | 307 | ... 36 more ... | 511;
     body: unknown;
-    headers: Record<string, string>
+    headers: Headers
 }
 ```
 

--- a/apps/example-next/tests/react-query.spec.tsx
+++ b/apps/example-next/tests/react-query.spec.tsx
@@ -829,6 +829,10 @@ describe('react-query', () => {
 
     const data = {
       status: 200,
+      headers: new Headers({
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer your_token_here',
+      }),
       body: {
         id: '1',
         title: 'foo',
@@ -837,7 +841,6 @@ describe('react-query', () => {
         content: 'baz',
         published: true,
       } as Post,
-      headers: {},
     } as const;
 
     const { waitForNextUpdate } = renderHook(

--- a/apps/example-next/tests/react-query.spec.tsx
+++ b/apps/example-next/tests/react-query.spec.tsx
@@ -831,7 +831,6 @@ describe('react-query', () => {
       status: 200,
       headers: new Headers({
         'Content-Type': 'application/json',
-        Authorization: 'Bearer your_token_here',
       }),
       body: {
         id: '1',

--- a/apps/example-next/tests/react-query.spec.tsx
+++ b/apps/example-next/tests/react-query.spec.tsx
@@ -837,6 +837,7 @@ describe('react-query', () => {
         content: 'baz',
         published: true,
       } as Post,
+      headers: {},
     } as const;
 
     const { waitForNextUpdate } = renderHook(

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -208,14 +208,10 @@ describe('client', () => {
 
       const result = await client.posts.getPosts({});
 
-      expect(result).toStrictEqual({
-        body: value,
-        status: 200,
-        headers: {
-          'content-length': '15',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual(value);
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('15');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
 
     it('w/ no query parameters', async () => {
@@ -232,14 +228,10 @@ describe('client', () => {
 
       const result = await client.posts.getPosts({ query: {} });
 
-      expect(result).toStrictEqual({
-        body: value,
-        status: 200,
-        headers: {
-          'content-length': '15',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual(value);
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('15');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
 
     it('w/ no parameters (not provided)', async () => {
@@ -256,14 +248,10 @@ describe('client', () => {
 
       const result = await client.posts.getPosts();
 
-      expect(result).toStrictEqual({
-        body: value,
-        status: 200,
-        headers: {
-          'content-length': '15',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual(value);
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('15');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
 
     it('w/ query parameters', async () => {
@@ -280,14 +268,10 @@ describe('client', () => {
 
       const result = await client.posts.getPosts({ query: { take: 10 } });
 
-      expect(result).toStrictEqual({
-        body: value,
-        status: 200,
-        headers: {
-          'content-length': '15',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual(value);
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('15');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
 
     it('w/ json query parameters', async () => {
@@ -332,14 +316,10 @@ describe('client', () => {
         },
       });
 
-      expect(result).toStrictEqual({
-        body: value,
-        status: 200,
-        headers: {
-          'content-length': '15',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual(value);
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('15');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
 
     it('w/ undefined query parameters', async () => {
@@ -358,14 +338,10 @@ describe('client', () => {
         query: { take: 10, skip: undefined },
       });
 
-      expect(result).toStrictEqual({
-        body: value,
-        status: 200,
-        headers: {
-          'content-length': '15',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual(value);
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('15');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
 
     it('w/ sub path', async () => {
@@ -382,14 +358,10 @@ describe('client', () => {
 
       const result = await client.posts.getPost({ params: { id: '1' } });
 
-      expect(result).toStrictEqual({
-        body: value,
-        status: 200,
-        headers: {
-          'content-length': '15',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual(value);
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('15');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
 
     it('w/ a non json response (string)', async () => {
@@ -411,14 +383,10 @@ describe('client', () => {
 
       const result = await client.posts.getPosts({});
 
-      expect(result).toStrictEqual({
-        body: 'string',
-        status: 200,
-        headers: {
-          'content-length': '6',
-          'content-type': 'text/plain',
-        },
-      });
+      expect(result.body).toStrictEqual('string');
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('6');
+      expect(result.headers.get('Content-Type')).toBe('text/plain ');
     });
   });
 
@@ -439,14 +407,10 @@ describe('client', () => {
         body: { title: 'title', content: 'content', authorId: 'authorId' },
       });
 
-      expect(result).toStrictEqual({
-        body: value,
-        status: 200,
-        headers: {
-          'content-length': '15',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual(value);
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('15');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
 
     it('w/ query params', async () => {
@@ -466,14 +430,10 @@ describe('client', () => {
         body: {},
       });
 
-      expect(result).toStrictEqual({
-        body: {},
-        status: 200,
-        headers: {
-          'content-length': '2',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual({});
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('2');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
   });
 
@@ -500,14 +460,10 @@ describe('client', () => {
         body: { title: 'title', content: 'content', authorId: 'authorId' },
       });
 
-      expect(result).toStrictEqual({
-        body: value,
-        status: 200,
-        headers: {
-          'content-length': '15',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual(value);
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('15');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
   });
 
@@ -529,14 +485,10 @@ describe('client', () => {
         body: null,
       });
 
-      expect(result).toStrictEqual({
-        body: value,
-        status: 200,
-        headers: {
-          'content-length': '15',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual(value);
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('15');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
   });
 
@@ -558,14 +510,10 @@ describe('client', () => {
         body: null,
       });
 
-      expect(result).toStrictEqual({
-        body: value,
-        status: 200,
-        headers: {
-          'content-length': '15',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual(value);
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('15');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
   });
 
@@ -585,14 +533,10 @@ describe('client', () => {
         body: { file },
       });
 
-      expect(result).toStrictEqual({
-        body: value,
-        status: 200,
-        headers: {
-          'content-length': '15',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual(value);
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('15');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
 
       expect(fetchMock).toHaveLastFetched(true, {
         matcher: (_, options) => {
@@ -618,14 +562,10 @@ describe('client', () => {
         body: formData,
       });
 
-      expect(result).toStrictEqual({
-        body: value,
-        status: 200,
-        headers: {
-          'content-length': '15',
-          'content-type': 'application/json',
-        },
-      });
+      expect(result.body).toStrictEqual(value);
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Length')).toBe('15');
+      expect(result.headers.get('Content-Type')).toBe('application/json');
 
       expect(fetchMock).toHaveLastFetched(true, {
         matcher: (_, options) => {
@@ -658,7 +598,6 @@ const customClient = initClient(router, {
     return {
       status: 200,
       body: { message: 'Hello' },
-      headers: {},
     };
   },
 });

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -598,6 +598,7 @@ const customClient = initClient(router, {
     return {
       status: 200,
       body: { message: 'Hello' },
+      headers: new Headers(),
     };
   },
 });

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -208,7 +208,14 @@ describe('client', () => {
 
       const result = await client.posts.getPosts({});
 
-      expect(result).toStrictEqual({ body: value, status: 200 });
+      expect(result).toStrictEqual({
+        body: value,
+        status: 200,
+        headers: {
+          'content-length': '15',
+          'content-type': 'application/json',
+        },
+      });
     });
 
     it('w/ no query parameters', async () => {
@@ -225,7 +232,14 @@ describe('client', () => {
 
       const result = await client.posts.getPosts({ query: {} });
 
-      expect(result).toStrictEqual({ body: value, status: 200 });
+      expect(result).toStrictEqual({
+        body: value,
+        status: 200,
+        headers: {
+          'content-length': '15',
+          'content-type': 'application/json',
+        },
+      });
     });
 
     it('w/ no parameters (not provided)', async () => {
@@ -242,7 +256,14 @@ describe('client', () => {
 
       const result = await client.posts.getPosts();
 
-      expect(result).toStrictEqual({ body: value, status: 200 });
+      expect(result).toStrictEqual({
+        body: value,
+        status: 200,
+        headers: {
+          'content-length': '15',
+          'content-type': 'application/json',
+        },
+      });
     });
 
     it('w/ query parameters', async () => {
@@ -259,7 +280,14 @@ describe('client', () => {
 
       const result = await client.posts.getPosts({ query: { take: 10 } });
 
-      expect(result).toStrictEqual({ body: value, status: 200 });
+      expect(result).toStrictEqual({
+        body: value,
+        status: 200,
+        headers: {
+          'content-length': '15',
+          'content-type': 'application/json',
+        },
+      });
     });
 
     it('w/ json query parameters', async () => {
@@ -304,7 +332,14 @@ describe('client', () => {
         },
       });
 
-      expect(result).toStrictEqual({ body: value, status: 200 });
+      expect(result).toStrictEqual({
+        body: value,
+        status: 200,
+        headers: {
+          'content-length': '15',
+          'content-type': 'application/json',
+        },
+      });
     });
 
     it('w/ undefined query parameters', async () => {
@@ -323,7 +358,14 @@ describe('client', () => {
         query: { take: 10, skip: undefined },
       });
 
-      expect(result).toStrictEqual({ body: value, status: 200 });
+      expect(result).toStrictEqual({
+        body: value,
+        status: 200,
+        headers: {
+          'content-length': '15',
+          'content-type': 'application/json',
+        },
+      });
     });
 
     it('w/ sub path', async () => {
@@ -340,7 +382,14 @@ describe('client', () => {
 
       const result = await client.posts.getPost({ params: { id: '1' } });
 
-      expect(result).toStrictEqual({ body: value, status: 200 });
+      expect(result).toStrictEqual({
+        body: value,
+        status: 200,
+        headers: {
+          'content-length': '15',
+          'content-type': 'application/json',
+        },
+      });
     });
 
     it('w/ a non json response (string)', async () => {
@@ -362,7 +411,14 @@ describe('client', () => {
 
       const result = await client.posts.getPosts({});
 
-      expect(result).toStrictEqual({ body: 'string', status: 200 });
+      expect(result).toStrictEqual({
+        body: 'string',
+        status: 200,
+        headers: {
+          'content-length': '6',
+          'content-type': 'text/plain',
+        },
+      });
     });
   });
 
@@ -383,7 +439,14 @@ describe('client', () => {
         body: { title: 'title', content: 'content', authorId: 'authorId' },
       });
 
-      expect(result).toStrictEqual({ body: value, status: 200 });
+      expect(result).toStrictEqual({
+        body: value,
+        status: 200,
+        headers: {
+          'content-length': '15',
+          'content-type': 'application/json',
+        },
+      });
     });
 
     it('w/ query params', async () => {
@@ -403,7 +466,14 @@ describe('client', () => {
         body: {},
       });
 
-      expect(result).toStrictEqual({ body: {}, status: 200 });
+      expect(result).toStrictEqual({
+        body: {},
+        status: 200,
+        headers: {
+          'content-length': '2',
+          'content-type': 'application/json',
+        },
+      });
     });
   });
 
@@ -430,7 +500,14 @@ describe('client', () => {
         body: { title: 'title', content: 'content', authorId: 'authorId' },
       });
 
-      expect(result).toStrictEqual({ body: value, status: 200 });
+      expect(result).toStrictEqual({
+        body: value,
+        status: 200,
+        headers: {
+          'content-length': '15',
+          'content-type': 'application/json',
+        },
+      });
     });
   });
 
@@ -452,7 +529,14 @@ describe('client', () => {
         body: null,
       });
 
-      expect(result).toStrictEqual({ body: value, status: 200 });
+      expect(result).toStrictEqual({
+        body: value,
+        status: 200,
+        headers: {
+          'content-length': '15',
+          'content-type': 'application/json',
+        },
+      });
     });
   });
 
@@ -474,7 +558,14 @@ describe('client', () => {
         body: null,
       });
 
-      expect(result).toStrictEqual({ body: value, status: 200 });
+      expect(result).toStrictEqual({
+        body: value,
+        status: 200,
+        headers: {
+          'content-length': '15',
+          'content-type': 'application/json',
+        },
+      });
     });
   });
 
@@ -494,7 +585,14 @@ describe('client', () => {
         body: { file },
       });
 
-      expect(result).toStrictEqual({ body: value, status: 200 });
+      expect(result).toStrictEqual({
+        body: value,
+        status: 200,
+        headers: {
+          'content-length': '15',
+          'content-type': 'application/json',
+        },
+      });
 
       expect(fetchMock).toHaveLastFetched(true, {
         matcher: (_, options) => {
@@ -520,7 +618,14 @@ describe('client', () => {
         body: formData,
       });
 
-      expect(result).toStrictEqual({ body: value, status: 200 });
+      expect(result).toStrictEqual({
+        body: value,
+        status: 200,
+        headers: {
+          'content-length': '15',
+          'content-type': 'application/json',
+        },
+      });
 
       expect(fetchMock).toHaveLastFetched(true, {
         matcher: (_, options) => {
@@ -553,6 +658,7 @@ const customClient = initClient(router, {
     return {
       status: 200,
       body: { message: 'Hello' },
+      headers: {},
     };
   },
 });

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -386,7 +386,7 @@ describe('client', () => {
       expect(result.body).toStrictEqual('string');
       expect(result.status).toBe(200);
       expect(result.headers.get('Content-Length')).toBe('6');
-      expect(result.headers.get('Content-Type')).toBe('text/plain ');
+      expect(result.headers.get('Content-Type')).toBe('text/plain');
     });
   });
 

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -102,7 +102,7 @@ export type ApiRouteResponseNoUnknownStatus<T> =
       [K in keyof T]: {
         status: K;
         body: ZodInferOrType<T[K]>;
-        headers: Record<string, string>;
+        headers: Headers;
       };
     }[keyof T];
 
@@ -111,7 +111,7 @@ export type ApiRouteResponse<T> =
   | {
       status: Exclude<HTTPStatusCode, keyof T>;
       body: unknown;
-      headers: Record<string, string>;
+      headers: Headers;
     };
 
 /**
@@ -177,7 +177,7 @@ export type ApiFetcherArgs = {
 export type ApiFetcher = (args: ApiFetcherArgs) => Promise<{
   status: number;
   body: unknown;
-  headers: Record<string, string>;
+  headers?: Headers;
 }>;
 
 /**
@@ -204,28 +204,23 @@ export const tsRestFetchApi: ApiFetcher = async ({
   });
   const contentType = result.headers.get('content-type');
 
-  const responseHeaders: Record<string, string> = {};
-  result.headers.forEach((value, key) => {
-    responseHeaders[key] = value;
-  });
-
   if (contentType?.includes('application/json')) {
     return {
       status: result.status,
       body: await result.json(),
-      headers: responseHeaders,
+      headers: result.headers,
     };
   } else if (contentType?.includes('text/plain')) {
     return {
       status: result.status,
       body: await result.text(),
-      headers: responseHeaders,
+      headers: result.headers,
     };
   } else {
     return {
       status: result.status,
       body: await result.blob(),
-      headers: responseHeaders,
+      headers: result.headers,
     };
   }
 };

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -177,7 +177,7 @@ export type ApiFetcherArgs = {
 export type ApiFetcher = (args: ApiFetcherArgs) => Promise<{
   status: number;
   body: unknown;
-  headers?: Headers;
+  headers: Headers;
 }>;
 
 /**

--- a/libs/ts-rest/react-query/src/lib/types.ts
+++ b/libs/ts-rest/react-query/src/lib/types.ts
@@ -78,12 +78,17 @@ type ErrorResponseMapper<T> =
   | {
       [K in keyof T]: K extends SuccessfulHttpStatusCode
         ? never
-        : { status: K; body: ZodInferOrType<T[K]>;  headers: Record<string, string>};
+        : {
+            status: K;
+            body: ZodInferOrType<T[K]>;
+            headers: Record<string, string>;
+          };
     }[keyof T]
   // If the response isn't one of our typed ones. Return "unknown"
   | {
       status: Exclude<HTTPStatusCode, keyof T | SuccessfulHttpStatusCode>;
       body: unknown;
+      headers: Record<string, string>;
     };
 
 // Data response if it's a 2XX

--- a/libs/ts-rest/react-query/src/lib/types.ts
+++ b/libs/ts-rest/react-query/src/lib/types.ts
@@ -67,7 +67,7 @@ export type DataReturnArgs<
  */
 type SuccessResponseMapper<T> = {
   [K in keyof T]: K extends SuccessfulHttpStatusCode
-    ? { status: K; body: ZodInferOrType<T[K]>; headers: Record<string, string> }
+    ? { status: K; body: ZodInferOrType<T[K]>; headers: Headers }
     : never;
 }[keyof T];
 
@@ -81,14 +81,14 @@ type ErrorResponseMapper<T> =
         : {
             status: K;
             body: ZodInferOrType<T[K]>;
-            headers: Record<string, string>;
+            headers: Headers;
           };
     }[keyof T]
   // If the response isn't one of our typed ones. Return "unknown"
   | {
       status: Exclude<HTTPStatusCode, keyof T | SuccessfulHttpStatusCode>;
       body: unknown;
-      headers: Record<string, string>;
+      headers: Headers;
     };
 
 // Data response if it's a 2XX

--- a/libs/ts-rest/react-query/src/lib/types.ts
+++ b/libs/ts-rest/react-query/src/lib/types.ts
@@ -67,7 +67,7 @@ export type DataReturnArgs<
  */
 type SuccessResponseMapper<T> = {
   [K in keyof T]: K extends SuccessfulHttpStatusCode
-    ? { status: K; body: ZodInferOrType<T[K]> }
+    ? { status: K; body: ZodInferOrType<T[K]>; headers: Record<string, string> }
     : never;
 }[keyof T];
 
@@ -78,7 +78,7 @@ type ErrorResponseMapper<T> =
   | {
       [K in keyof T]: K extends SuccessfulHttpStatusCode
         ? never
-        : { status: K; body: ZodInferOrType<T[K]> };
+        : { status: K; body: ZodInferOrType<T[K]>;  headers: Record<string, string>};
     }[keyof T]
   // If the response isn't one of our typed ones. Return "unknown"
   | {

--- a/libs/ts-rest/solid-query/src/lib/solid-query.ts
+++ b/libs/ts-rest/solid-query/src/lib/solid-query.ts
@@ -101,7 +101,7 @@ type DataReturnArgs<
  */
 type SuccessResponseMapper<T> = {
   [K in keyof T]: K extends SuccessfulHttpStatusCode
-    ? { status: K; body: ZodInferOrType<T[K]>; headers: Record<string, string> }
+    ? { status: K; body: ZodInferOrType<T[K]>; headers: Headers }
     : never;
 }[keyof T];
 
@@ -115,14 +115,14 @@ type ErrorResponseMapper<T> =
         : {
             status: K;
             body: ZodInferOrType<T[K]>;
-            headers: Record<string, string>;
+            headers: Headers;
           };
     }[keyof T]
   // If the response isn't one of our typed ones. Return "unknown"
   | {
       status: Exclude<HTTPStatusCode, keyof T | SuccessfulHttpStatusCode>;
       body: unknown;
-      headers: Record<string, string>;
+      headers: Headers;
     };
 
 // Data response if it's a 2XX

--- a/libs/ts-rest/solid-query/src/lib/solid-query.ts
+++ b/libs/ts-rest/solid-query/src/lib/solid-query.ts
@@ -101,7 +101,7 @@ type DataReturnArgs<
  */
 type SuccessResponseMapper<T> = {
   [K in keyof T]: K extends SuccessfulHttpStatusCode
-    ? { status: K; body: ZodInferOrType<T[K]> }
+    ? { status: K; body: ZodInferOrType<T[K]>; headers: Record<string, string> }
     : never;
 }[keyof T];
 
@@ -112,12 +112,17 @@ type ErrorResponseMapper<T> =
   | {
       [K in keyof T]: K extends SuccessfulHttpStatusCode
         ? never
-        : { status: K; body: ZodInferOrType<T[K]> };
+        : {
+            status: K;
+            body: ZodInferOrType<T[K]>;
+            headers: Record<string, string>;
+          };
     }[keyof T]
   // If the response isn't one of our typed ones. Return "unknown"
   | {
       status: Exclude<HTTPStatusCode, keyof T | SuccessfulHttpStatusCode>;
       body: unknown;
+      headers: Record<string, string>;
     };
 
 // Data response if it's a 2XX


### PR DESCRIPTION
This pull request addresses the enhancement issue #221, wherein we aim to expose response headers to the clients. This could be a breaking change for those using custom API fetchers but will offer a significant improvement in functionality.

Changes:

- The headers have been added to the client fetcher return type in ApiFetcher.
- Added header to both React query and core client
- Updated test fixtures

Notes:

This change may fail type-checking/compiling, but it will not cause any runtime errors as no one would be consuming the non-existent headers. The fix is simple and straightforward. This update prioritizes long-term utility and clarity over short-term compatibility, and we believe it will be greatly beneficial in the long run.

Please review and provide feedback.

/cc @Gabrola, @oliverbutler