### PR TITLE
feat: add fastify plugin implementation

### DIFF
--- a/.changeset/pink-dogs-kneel.md
+++ b/.changeset/pink-dogs-kneel.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/fastify': major
+---
+
+Added support for registering ts-rest as a Fastify plugin

--- a/apps/docs/docs/fastify.mdx
+++ b/apps/docs/docs/fastify.mdx
@@ -37,7 +37,7 @@ const router = s.router(contract, {
   },
 });
 
-s.registerRouter(contract, router, app);
+app.register(s.plugin(router));
 
 const start = async () => {
   try {

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -245,7 +245,7 @@ const router = s.router(contract, {
   },
 });
 
-s.registerRouter(contract, router, app);
+app.register(s.plugin(router));
 
 const start = async () => {
   try {

--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.spec.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.spec.ts
@@ -120,6 +120,21 @@ describe('ts-rest-fastify', () => {
     expect(response.body).toEqual({ foo: 'bar' });
   });
 
+  it('should allow for options when using plugin instance', async () => {
+    const app = fastify({ logger: false });
+
+    app.register(s.plugin(router), {
+      responseValidation: true,
+    });
+
+    await app.ready();
+
+    const response = await supertest(app.server).get('/wrong');
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual({ foo: 'bar' });
+  });
+
   it('should parse body correctly', async () => {
     const app = fastify({ logger: false });
 

--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.spec.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.spec.ts
@@ -107,6 +107,19 @@ describe('ts-rest-fastify', () => {
     expect(response.body).toEqual({ foo: 'bar' });
   });
 
+  it('should instantiate fastify routes using plugin instance', async () => {
+    const app = fastify({ logger: false });
+
+    app.register(s.plugin(router));
+
+    await app.ready();
+
+    const response = await supertest(app.server).get('/test');
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual({ foo: 'bar' });
+  });
+
   it('should parse body correctly', async () => {
     const app = fastify({ logger: false });
 

--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
@@ -173,7 +173,16 @@ export const initServer = () => ({
     <T extends AppRouter>(
       router: InitialisedRouter<T>
     ): fastify.FastifyPluginCallback<RegisterRouterOptions> =>
-    (app, opts, done) => {
+    (
+      app,
+      opts = {
+        logInitialization: true,
+        jsonQuery: false,
+        responseValidation: false,
+        requestValidationErrorHandler: 'combined',
+      },
+      done
+    ) => {
       recursivelyRegisterRouter(router.routes, router.contract, [], app, opts);
 
       app.setErrorHandler(


### PR DESCRIPTION
This PR adds the Fastify plugin implementation which aims to replace `registerRouter` in which we have to pass more arguments than we actually need. 

This does however change the return type of the `router` method on `initServer` but there shouldn't be any unintended consequences from this change. 