### PR TITLE
Fix cjs usage of libraries

### DIFF
--- a/.changeset/moody-falcons-confess.md
+++ b/.changeset/moody-falcons-confess.md
@@ -1,0 +1,12 @@
+---
+'@ts-rest/core': patch
+'@ts-rest/express': patch
+'@ts-rest/fastify': patch
+'@ts-rest/nest': patch
+'@ts-rest/next': patch
+'@ts-rest/open-api': patch
+'@ts-rest/react-query': patch
+'@ts-rest/solid-query': patch
+---
+
+Fix ESM/CJS issues in package.json

--- a/libs/ts-rest/core/project.json
+++ b/libs/ts-rest/core/project.json
@@ -27,8 +27,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/express/project.json
+++ b/libs/ts-rest/express/project.json
@@ -27,8 +27,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/fastify/project.json
+++ b/libs/ts-rest/fastify/project.json
@@ -27,8 +27,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/nest/project.json
+++ b/libs/ts-rest/nest/project.json
@@ -27,8 +27,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/next/project.json
+++ b/libs/ts-rest/next/project.json
@@ -27,8 +27,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/open-api/project.json
+++ b/libs/ts-rest/open-api/project.json
@@ -27,8 +27,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "publish": {

--- a/libs/ts-rest/react-query/project.json
+++ b/libs/ts-rest/react-query/project.json
@@ -28,8 +28,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "lint": {

--- a/libs/ts-rest/solid-query/project.json
+++ b/libs/ts-rest/solid-query/project.json
@@ -28,8 +28,7 @@
         "format": ["esm", "cjs"],
         "compiler": "tsc",
         "rollupConfig": "tools/scripts/rollup.config.js",
-        "generateExportsField": true,
-        "skipTypeField": true
+        "generateExportsField": true
       }
     },
     "lint": {

--- a/tools/scripts/fix-esm.mjs
+++ b/tools/scripts/fix-esm.mjs
@@ -18,6 +18,8 @@ for (const lib of libs) {
     ...JSON.parse(packageJson),
     module: './index.mjs',
     main: './index.js',
+    // Ensure that esm is not forced due to "type": "module" being added.
+    type: undefined,
     exports: {
       '.': {
         types: './src/index.d.ts',


### PR DESCRIPTION
Trying to upgrade from 3.22 to 3.25 I am getting the following error:

```
    const exports = origRequire.apply(this, arguments)
                                ^
Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/maxbrosnahan/project/node_modules/@ts-rest/nest/index.js from /Users/maxbrosnahan/project/dist/main.js not supported.
index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /Users/maxbrosnahan/project/node_modules/@ts-rest/nest/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

```

To fix this I have added an override in the fix-esm script.

## Before
![Skjermbilde 2023-06-03 kl  22 02 11](https://github.com/ts-rest/ts-rest/assets/1177034/313127ab-cdb0-4bd4-b537-e447bbf045fa)


## After
![Skjermbilde 2023-06-03 kl  22 06 53](https://github.com/ts-rest/ts-rest/assets/1177034/6e41a58b-c493-4c07-b591-8562970409f0)


