### PR TITLE
Docs: updated warning as of pathPrefix implementation

### DIFF
--- a/apps/docs/docs/nest.mdx
+++ b/apps/docs/docs/nest.mdx
@@ -138,8 +138,5 @@ Currently any existing Nest global prefix, versioning, or controller prefixes wi
 
 If this feature is highly requested, we can investigate a solution.
 
-Currently the path in your contract must be the **full path**, your client may specify a different base url, with a prefix, but this cannot be done at the contract level currently.
-
-e.g. if your client is at `https://api.example.com/v1` and your contract is at `/posts`, the client will make a request to `https://api.example.com/v1/posts`.
-
+We have added the ability to [prefix paths](/docs/core/#path-prefix), allowing more flexibility in defining your API endpoints. This can be used as a workaround for this functionality.
 :::


### PR DESCRIPTION
In Nest, global prefix, versioning, or controller prefixes provide options for adding prefixes to paths in your APIs which we do not support.

Previously, there was a warning stating:

'Currently any existing Nest global prefix, versioning, or controller prefixes will be ignored, please see https://github.com/ts-rest/ts-rest/issues/70 for more details.

Currently, the path in your contract must be the **full path**. Your client may specify a different base URL with a prefix, but this cannot be done at the contract level currently.'

However, we have now introduced the ability to add path prefixes. This serves as a workaround for this missing functionality.

I have updated the documentation to reflect this change:

'Currently any existing Nest global prefix, versioning, or controller prefixes will be ignored, please see https://github.com/ts-rest/ts-rest/issues/70 for more details.

We have added the ability to [prefix paths](/docs/core/#path-prefix), allowing more flexibility in defining your API endpoints. This can be used as a workaround for this functionality.'

omg this PR is longer then the change 😂
