### PR TITLE
add @tanstack/react-query as a package to install alongside with @ts-rest/react-query

### DIFF
--- a/apps/docs/docs/react-query.mdx
+++ b/apps/docs/docs/react-query.mdx
@@ -4,7 +4,7 @@ import { InstallTabs } from '@site/src/components/InstallTabs';
 
 ## Installation
 
-<InstallTabs packageName="@ts-rest/react-query" />
+<InstallTabs packageName="@ts-rest/react-query @tanstack/react-query" />
 
 This is a client using `@ts-rest/react-query`, using `@tanstack/react-query` under the hood.
 


### PR DESCRIPTION
Add peer dependency to install command to avoid issues when adopting the @ts-rest/react-query lib.

This should simplify the process for new comers.