### PR TITLE
feat: expose internal types for @ts-rest/express

### DIFF
--- a/.changeset/big-colts-carry.md
+++ b/.changeset/big-colts-carry.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/express': patch
+---
+
+Exposed `AppRouteOptions` and `AppRouteImplementation` types. They can be used to split router handlers.

--- a/.changeset/big-colts-carry.md
+++ b/.changeset/big-colts-carry.md
@@ -2,4 +2,4 @@
 '@ts-rest/express': patch
 ---
 
-Exposed `AppRouteOptions` and `AppRouteImplementation` types. They can be used to split router handlers.
+Exposed `AppRouteOptions` and `AppRouteImplementation` types. They allow for greater developer flexibility and can be used to split router handlers.

--- a/libs/ts-rest/express/src/index.ts
+++ b/libs/ts-rest/express/src/index.ts
@@ -1,3 +1,8 @@
 export * from './lib/ts-rest-express';
-export { TsRestRequest, TsRestRequestHandler } from './lib/types';
+export type {
+  AppRouteImplementation,
+  AppRouteOptions,
+  TsRestRequest,
+  TsRestRequestHandler,
+} from './lib/types';
 export { RequestValidationError } from './lib/request-validation-error';


### PR DESCRIPTION
# Summary

- resolves #312 

exposed useful internal types like `AppRouteOptions`.

## Example usage

```ts
import { AppRouteOptions } from '@ts-rest/express'

export type HandlerFor<T extends AppRoute> = AppRouteOptions<T>['handler']

// ...

type PatchDeps = Pick<ReviewsService, 'patchReviews'>
type MkPatch = (deps: PatchDeps) => HandlerFor<typeof contract.reviews.patch>
export const mkPatchReviews: MkPatch =
  ({ patchReviews }) =>
  async ({ params: { reviewsId }, req: { user } }) => {
    const { id: userId } = getUser.parse(user)
    const result = await patchReviews({ reviewsId, userId })

    return match(result)
      .with(P.instanceOf(ReviewNotFoundError), () => reviewNotFound)
      .otherwise(() => ({ status: 200, body: '리뷰 공개 여부가 업데이트되었습니다.' } as const))
  }

// ...
const postHandler = mkPostReviews({ createReviews })

export const reviews = s.router(contract.reviews, {
  post: {
    middleware: [authValidate(roleSet.all)],
    handler: postHandler,
  }
})
```