### PR TITLE
fix: return errors from fastify route handlers

### DIFF
--- a/.changeset/late-panthers-pump.md
+++ b/.changeset/late-panthers-pump.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/fastify': patch
+---
+
+Re-throw errors from route handlers

--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.spec.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.spec.ts
@@ -389,4 +389,33 @@ describe('ts-rest-fastify', () => {
     expect(responseCss.text).toEqual('body { color: red; }');
     expect(responseCss.header['content-type']).toEqual('text/css');
   });
+
+  it('should return errors from route handlers', async () => {
+    const erroringRouter = s.router(contract, {
+      test: async () => {
+        throw new Error('not implemented');
+      },
+      ping: async () => {
+        throw new Error('not implemented');
+      },
+      testPathParams: async () => {
+        throw new Error('not implemented');
+      },
+      returnsTheWrongData: async () => {
+        throw new Error('not implemented');
+      },
+    });
+
+    const app = fastify({ logger: false });
+
+    s.registerRouter(contract, erroringRouter, app);
+
+    await app.ready();
+
+    const response = await supertest(app.server)
+      .get('/test')
+      .timeout(1000)
+      .send({});
+    expect(response.statusCode).toEqual(500);
+  });
 });

--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
@@ -176,6 +176,8 @@ const requestValidationErrorHandler = (
       } else {
         return handler(err, request, reply);
       }
+    } else {
+      throw err;
     }
   };
 };


### PR DESCRIPTION
`requestValidationErrorHandler` currently only handles `RequestValidationError` while silently consuming all other errors. This means that if there is any unhandled error in a route handler, the request never completes.

I added a test case for demonstration, and fixed the issue by re-throwing errors other than `RequestValidationError`.
