### PR TITLE
fix(ts-rest-fastify): fix request body validation

### DIFF
--- a/.changeset/light-hotels-think.md
+++ b/.changeset/light-hotels-think.md
@@ -2,4 +2,4 @@
 '@ts-rest/fastify': patch
 ---
 
-Use the parsed request body from zod
+Pass the parsed request body from zod to the route handler instead of the original request. 

--- a/.changeset/light-hotels-think.md
+++ b/.changeset/light-hotels-think.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/fastify': patch
+---
+
+Use the parsed request body from zod

--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.spec.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.spec.ts
@@ -220,6 +220,42 @@ describe('ts-rest-fastify', () => {
     expect(response.body).toEqual({ id: 'foo' });
   });
 
+  it('should remove extra properties from request body', async () => {
+    const contract = c.router({
+      echo: {
+        method: 'POST',
+        path: '/echo',
+        body: z.object({
+          foo: z.string(),
+        }),
+        responses: {
+          200: z.any(),
+        },
+      },
+    });
+
+    const router = s.router(contract, {
+      echo: async ({ body }) => {
+        return {
+          status: 200,
+          body: body,
+        };
+      },
+    });
+
+    const app = fastify({ logger: false });
+
+    s.registerRouter(contract, router, app);
+
+    await app.ready();
+
+    const response = await supertest(app.server).post('/echo').send({
+      foo: 'bar',
+      bar: 'foo',
+    });
+    expect(response.body).toEqual({ foo: 'bar' });
+  });
+
   it('options.responseValidation true should remove extra properties', async () => {
     const app = fastify({ logger: false });
 

--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
@@ -216,7 +216,7 @@ const registerRoute = <TAppRoute extends AppRoute>(
         headers: validationResults.headersResult.data as any,
         request,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        body: request.body as any,
+        body: validationResults.bodyResult.data as any,
         reply,
       });
 


### PR DESCRIPTION
`@ts-rest/fastify` currently passes the original request body to the route handler, not the one parsed by zod.
This breaks some zod features that change the output, such as
- [Default values](https://zod.dev/?id=default)
- [Primitive coercion](https://zod.dev/?id=coercion-for-primitives)
- [Transform](https://zod.dev/?id=transform)
- [Preprocess](https://zod.dev/?id=preprocess)
- Stripping unknown fields

This PR fixes that by passing the parsed request body to the route handler instead, like `@ts-rest/express`.