### PR TITLE
docs: update `swagger` to `transformObject`

### DIFF
--- a/apps/docs/docs/fastify/openapi.mdx
+++ b/apps/docs/docs/fastify/openapi.mdx
@@ -37,7 +37,7 @@ import { openApiDocument } from './document'
 
 const app = fastify()
   .register(fastifySwagger, {
-    swagger: openApiDocument
+    transformObject: () => openApiDocument
   })
   .register(fastifySwaggerUI)
 ```


### PR DESCRIPTION
This PR update the fastify swagger integration in openapi guide.

The previous implementation using the `swagger` option can not load descriptions or schemas from the @ts-rest/open-api generated document.

[Preview](https://stackblitz.com/edit/ts-rest-fastify-oas?file=index.js)