### PR TITLE
fix(ts-rest-open-api): pathParams and query descriptions from `zod` `.describe()`

### DIFF
--- a/.changeset/new-kids-add.md
+++ b/.changeset/new-kids-add.md
@@ -1,0 +1,5 @@
+---
+"@ts-rest/open-api": patch
+---
+
+fix(ts-rest-open-api): pathParams and query descriptions from `zod` `.describe()`

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
@@ -68,7 +68,7 @@ const postsRouter = c.router({
     method: 'GET',
     path: `/posts/:id/comments/:commentId`,
     pathParams: z.object({
-      commentId: z.string().length(5),
+      commentId: z.string().length(5).describe("the comment ID"),
     }),
     responses: {
       200: c.response<Post | null>(),
@@ -324,6 +324,7 @@ const expectedApiDoc = {
             in: 'path',
             name: 'commentId',
             required: true,
+            description: 'the comment ID',
             schema: {
               type: 'string',
               minLength: 5,
@@ -571,7 +572,7 @@ describe('ts-rest-open-api', () => {
           },
           query: z
             .object({
-              foo: z.string(),
+              foo: z.string().describe("Foo"),
             })
             .refine((v) => v.foo === 'bar', {
               message: 'foo must be bar',
@@ -596,6 +597,7 @@ describe('ts-rest-open-api', () => {
               description: undefined,
               parameters: [
                 {
+                  description: 'Foo',
                   in: 'query',
                   name: 'foo',
                   required: true,


### PR DESCRIPTION
Move `"description"` out of `"schema"` as per OpenAPI spec: https://spec.openapis.org/oas/v3.1.0#parameter-object

Fixes #305