### PR TITLE
fix: fix CI by updating package.json engines

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,12 +33,12 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.16
+          node-version: 18.17.1
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.6
+          version: 8.7
 
       - name: 'Install dependencies'
         run: pnpm install
@@ -66,12 +66,12 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.16
+          node-version: 18.17.1
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8.6
+          version: 8.7
 
       - name: 'Install dependencies'
         run: pnpm install

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "nx": "nx"
   },
   "engines": {
-    "pnpm": "8.6",
-    "node": "18.16"
+    "pnpm": "8.7",
+    "node": "18.17.1"
   },
   "repository": "https://github.com/ts-rest/ts-rest",
   "private": true,

--- a/test-projects/nest-10/package.json
+++ b/test-projects/nest-10/package.json
@@ -5,6 +5,10 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "engines": {
+    "pnpm": "8.7",
+    "node": "18.17.1"
+  },
   "scripts": {
     "build": "nest build --type-check",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",

--- a/test-projects/nest-9/package.json
+++ b/test-projects/nest-9/package.json
@@ -5,6 +5,10 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "engines": {
+    "pnpm": "8.7",
+    "node": "18.17.1"
+  },
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",

--- a/test-projects/next-app-dir/package.json
+++ b/test-projects/next-app-dir/package.json
@@ -2,6 +2,10 @@
   "name": "next-app-dir",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "pnpm": "8.7",
+    "node": "18.17.1"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Our ci is failing with the following error:
```txt
Running pnpm install --frozen-lockfile
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your pnpm version is incompatible with "/home/runner/work/ts-rest/ts-rest".

Expected version: 8.6
Got: 8.7.0

This is happening because the package's manifest has an engines.pnpm field specified.
To fix this issue, install the required pnpm version globally.

To install the latest version of pnpm, run "pnpm i -g pnpm".
To check your pnpm version, run "pnpm -v".

Your Node version is incompatible with "/home/runner/work/ts-rest/ts-rest".

Expected version: 18.16
Got: v18.17.1

This is happening because the package's manifest has an engines.node field specified.
To fix this issue, install the required Node version.
```

Solution is to make package.json compatible with the (likely updated) GHA. 