### PR TITLE
feat: add better typing for TsRestRequest

### DIFF
--- a/.changeset/late-dingos-search.md
+++ b/.changeset/late-dingos-search.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/express': minor
+---
+
+Stronger typing for the `req` object in route handler implementations for express

--- a/.changeset/late-dingos-search.md
+++ b/.changeset/late-dingos-search.md
@@ -2,4 +2,4 @@
 '@ts-rest/express': minor
 ---
 
-Stronger typing for the `req` object in route handler implementations for express
+feat: '@ts-rest/express' added stronger typing for the `req` object in the route handler for express

--- a/.changeset/late-dingos-search.md
+++ b/.changeset/late-dingos-search.md
@@ -2,4 +2,4 @@
 '@ts-rest/express': minor
 ---
 
-feat: '@ts-rest/express' added stronger typing for the `req` object in the route handler for express
+feat: added stronger typing for the `req` object in the route handler for '@ts-rest/express' 

--- a/libs/ts-rest/express/src/lib/types.spec.ts
+++ b/libs/ts-rest/express/src/lib/types.spec.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import { initContract } from '@ts-rest/core';
+import { AppRouteImplementation } from './types';
+import { IncomingHttpHeaders } from 'http';
+
+export type Equal<a, b> = (<T>() => T extends a ? 1 : 2) extends <
+  T
+>() => T extends b ? 1 : 2
+  ? true
+  : false;
+
+export type Expect<a extends true> = a;
+
+const c = initContract();
+
+const contract = c.router({
+  postIndex: {
+    method: 'POST',
+    path: `/index.html`,
+    body: z.object({
+      echoHtml: z.string(),
+    }),
+    query: z.object({
+      extraPath: z.string().optional(),
+    }),
+    headers: z.object({
+      'x-application-index': z.literal('index'),
+    }),
+    responses: {
+      200: c.otherResponse({
+        contentType: 'text/html',
+        body: z.string().regex(/^<([a-z][a-z0-9]*)\b[^>]*>(.*?)<\/\1>$/im),
+      }),
+    },
+  },
+});
+
+it('should have type inference on req', () => {
+  type PostIndexImplementation = AppRouteImplementation<
+    typeof contract.postIndex
+  >;
+
+  type PostIndexParam = Parameters<PostIndexImplementation>[0];
+
+  type PostIndexReq = PostIndexParam['req'];
+
+  type PostIndexBod = PostIndexReq['body'];
+
+  type ShouldHaveReq = Expect<
+    Equal<
+      PostIndexBod,
+      {
+        echoHtml: string;
+      }
+    >
+  >;
+
+  type PostIndexHeaders = PostIndexReq['headers'];
+
+  type ShouldHaveHeaders = Expect<
+    Equal<
+      PostIndexHeaders,
+      {
+        'x-application-index': 'index';
+      } & IncomingHttpHeaders
+    >
+  >;
+
+  type PostIndexQuery = PostIndexReq['query'];
+
+  type ShouldHaveQuery = Expect<
+    Equal<
+      PostIndexQuery,
+      {
+        extraPath?: string;
+      }
+    >
+  >;
+});

--- a/libs/ts-rest/express/src/lib/types.spec.ts
+++ b/libs/ts-rest/express/src/lib/types.spec.ts
@@ -14,9 +14,9 @@ export type Expect<a extends true> = a;
 const c = initContract();
 
 const contract = c.router({
-  postIndex: {
+  postSomethingIndex: {
     method: 'POST',
-    path: `/index.html`,
+    path: `/:something/index.html`,
     body: z.object({
       echoHtml: z.string(),
     }),
@@ -25,6 +25,9 @@ const contract = c.router({
     }),
     headers: z.object({
       'x-application-index': z.literal('index'),
+    }),
+    pathParams: z.object({
+      something: z.string(),
     }),
     responses: {
       200: c.otherResponse({
@@ -37,7 +40,7 @@ const contract = c.router({
 
 it('should have type inference on req', () => {
   type PostIndexImplementation = AppRouteImplementation<
-    typeof contract.postIndex
+    typeof contract.postSomethingIndex
   >;
 
   type PostIndexParam = Parameters<PostIndexImplementation>[0];
@@ -73,6 +76,17 @@ it('should have type inference on req', () => {
       PostIndexQuery,
       {
         extraPath?: string;
+      }
+    >
+  >;
+
+  type PostIndexParams = PostIndexReq['params'];
+
+  type ShouldHaveParams = Expect<
+    Equal<
+      PostIndexParams,
+      {
+        something: string;
       }
     >
   >;

--- a/libs/ts-rest/express/src/lib/types.ts
+++ b/libs/ts-rest/express/src/lib/types.ts
@@ -4,9 +4,15 @@ import {
   AppRouteQuery,
   AppRouter,
   ServerInferRequest,
+  ServerInferResponseBody,
   ServerInferResponses,
 } from '@ts-rest/core';
-import { Express, NextFunction, Response } from 'express-serve-static-core';
+import {
+  Express,
+  NextFunction,
+  Response,
+  Request,
+} from 'express-serve-static-core';
 import { RequestValidationError } from './request-validation-error';
 
 type AppRouteQueryImplementation<T extends AppRouteQuery> = (
@@ -32,10 +38,21 @@ export type AppRouteImplementation<T extends AppRoute> =
     ? AppRouteQueryImplementation<T>
     : never;
 
-export type TsRestRequest<T extends AppRouter | AppRoute> =
-  Express['request'] & {
-    tsRestRoute: FlattenAppRouter<T>;
-  };
+export type TsRestRequest<
+  T extends AppRouter | AppRoute,
+  F extends FlattenAppRouter<T> = FlattenAppRouter<T>,
+  S extends ServerInferRequest<F> = ServerInferRequest<F>
+> = Request<
+  'params' extends keyof S ? S['params'] : Express['request']['params'],
+  ServerInferResponseBody<F>,
+  'body' extends keyof S ? S['body'] : Express['request']['body'],
+  'query' extends keyof S ? S['query'] : Express['request']['query']
+> & {
+  tsRestRoute: F;
+  headers: 'headers' extends keyof S
+    ? S['headers']
+    : Express['request']['headers'];
+};
 
 export type TsRestRequestHandler<T extends AppRouter | AppRoute> = (
   req: TsRestRequest<T>,


### PR DESCRIPTION
This PR adds better type inference for the `req` object of route implementations when using `@ts-rest/express`.

Consider this minimal example, modified from here

https://github.com/tefkah/ts-rest/blob/2073f362cbb1eb35a8bd06e65f36494dc2d8ed8c/libs/ts-rest/express/src/lib/ts-rest-express.spec.ts#L99-L104

Before this PR, after adding `req` to the destructuring argument like so 
```ts
      postIndex: async ({ body: { echoHtml }, req }) => {
```

it would have type `any`

```ts
      postIndex: async ({ body: { echoHtml }, req }) => {
			const body = req.body
				  //  ^? const body: any
```

After this PR, it will have type `{ echoHtml: string }`, i.e.
```ts
      postIndex: async ({ body: { echoHtml }, req }) => {
			const body = req.body
				  //  ^? const body: { echoHtml: string }
```						

Also `req.headers`, `req.query`, and `req.params` will be typed.


I'm not sure what the best practice is to test this, given that there weren't any type tests in `libs/ts-rest/express/src/lib`, so I added one. Feel free to remove it if it, it's more for demonstration purposes.


I also tried to type the `res` object better, but ran into problems there for cases where `strictStatusCodes` is `false` or when there are multiple statuscodes defined. Typescript will try to merge the statuscodes/response jsons like [in this stackoverflow question](https://stackoverflow.com/questions/75239505/using-unions-to-type-express-response-body-inside-generic-argument-or-outside), which leads to a very bad DX. 


Let me know what you think!