### PR TITLE
feat: add response validation to the client

### DIFF
--- a/.changeset/afraid-eagles-report.md
+++ b/.changeset/afraid-eagles-report.md
@@ -2,4 +2,4 @@
 '@ts-rest/core': minor
 ---
 
-add support for client-side response validation against the schema
+feat: add support for client-side response validation against contract schemas for `@ts-rest/core`

--- a/.changeset/afraid-eagles-report.md
+++ b/.changeset/afraid-eagles-report.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': minor
+---
+
+add support for client-side response validation against the schema

--- a/apps/docs/docs/core/core.md
+++ b/apps/docs/docs/core/core.md
@@ -228,6 +228,23 @@ export const contract = c.router({
 });
 ```
 
+:::caution
+When using `zod` as the schema, should the validation fail, the error will be thrown as a `ZodError`.
+
+You can catch this error and handle it however you like.
+
+```typescript
+try {
+  const posts = await client.getPosts();
+} catch (error) {
+  if (error instanceof ZodError) {
+    // handle error
+  }
+}
+```
+
+:::
+
 ## Metadata
 
 You can attach metadata with any type to your contract routes that can be accessed anywhere throughout ts-rest where

--- a/apps/docs/docs/core/core.md
+++ b/apps/docs/docs/core/core.md
@@ -90,13 +90,16 @@ This will force the client to always pass
 
 ```typescript
 const c = initContract();
-export const contract = c.router({
-  // ...endpoints
-}, {
-  baseHeaders: z.object({
-    authorization: z.string(),
-  }),
-});
+export const contract = c.router(
+  {
+    // ...endpoints
+  },
+  {
+    baseHeaders: z.object({
+      authorization: z.string(),
+    }),
+  }
+);
 ```
 
 ## Responses
@@ -161,6 +164,38 @@ export const contract = c.router({
   getPosts: {
     ...,
     strictStatusCodes: true,
+  }
+});
+```
+
+### Schema validation on the client
+
+By default, all responses are inferred at the type-level by the client using the contract, and are not validated at runtime.
+
+However, you can use the `validateResponseOnClient` option to validate the response at runtime by checking it against the defined schema associated with the status code in the contract. By default, this option is set to `false`.
+
+If you would like to enable this functionality for all routes in the contract, you can set the `validateResponseOnClient` option to `true` when initializing the contract.
+
+```typescript
+const c = initContract();
+export const contract = c.router({
+  {
+    ... // endpoints
+  },
+  {
+    validateResponseOnClient: true,
+  }
+});
+```
+
+You can also control this option on a per-route basis which will also override the globally set option.
+
+```typescript
+const c = initContract();
+export const contract = c.router({
+  getPosts: {
+    ...,
+    validateResponseOnClient: true,
   }
 });
 ```
@@ -254,13 +289,16 @@ You can assign `baseHeaders` which will be merged with the contract `headers`. H
 
 ```typescript
 const c = initContract();
-export const contract = c.router({
-  // ...endpoints
-}, {
-  baseHeaders: z.object({
+export const contract = c.router(
+  {
+    // ...endpoints
+  },
+  {
+    baseHeaders: z.object({
       authorization: z.string(),
     }),
-});
+  }
+);
 ```
 
 ### Path Prefix

--- a/apps/docs/docs/core/core.md
+++ b/apps/docs/docs/core/core.md
@@ -180,7 +180,7 @@ If you would like to enable this functionality for all routes in the contract, y
 const c = initContract();
 export const contract = c.router({
   {
-    ... // endpoints
+    // ...endpoints
   },
   {
     validateResponseOnClient: true,
@@ -199,6 +199,23 @@ export const contract = c.router({
   }
 });
 ```
+
+:::caution
+When using `zod` as the schema, should the validation fail, the error will be thrown as a `ZodError`.
+
+You can catch this error and handle it however you like.
+
+```typescript
+try {
+  const posts = await client.getPosts();
+} catch (error) {
+  if (error instanceof ZodError) {
+    // handle error
+  }
+}
+```
+
+:::
 
 ## Combining Contracts
 
@@ -227,23 +244,6 @@ export const contract = c.router({
   posts: postContract,
 });
 ```
-
-:::caution
-When using `zod` as the schema, should the validation fail, the error will be thrown as a `ZodError`.
-
-You can catch this error and handle it however you like.
-
-```typescript
-try {
-  const posts = await client.getPosts();
-} catch (error) {
-  if (error instanceof ZodError) {
-    // handle error
-  }
-}
-```
-
-:::
 
 ## Metadata
 

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -8,15 +8,15 @@ import {
   ClientInferResponses,
   PartialClientInferRequest,
   NextClientArgs,
-  Frameworks
+  Frameworks,
 } from './infer-types';
 
 type RecursiveProxyObj<T extends AppRouter, TClientArgs extends ClientArgs> = {
   [TKey in keyof T]: T[TKey] extends AppRoute
-  ? AppRouteFunction<T[TKey], TClientArgs>
-  : T[TKey] extends AppRouter
-  ? RecursiveProxyObj<T[TKey], TClientArgs>
-  : never;
+    ? AppRouteFunction<T[TKey], TClientArgs>
+    : T[TKey] extends AppRouter
+    ? RecursiveProxyObj<T[TKey], TClientArgs>
+    : never;
 };
 
 /**
@@ -90,7 +90,8 @@ export const tsRestFetchApi: ApiFetcher = async ({
   credentials,
   signal,
   cache,
-  next
+  next,
+  route,
 }) => {
   const result = await fetch(path, {
     method,
@@ -99,16 +100,24 @@ export const tsRestFetchApi: ApiFetcher = async ({
     credentials,
     signal,
     cache,
-    next
+    next,
     // we must type cast here because the typescript types for RequestInit
     // do not include properties like "next" for Frameworks (like Nextjs)
   } as RequestInit);
   const contentType = result.headers.get('content-type');
 
-  if (contentType?.includes("application/") && contentType?.includes('json')) {
+  if (contentType?.includes('application/') && contentType?.includes('json')) {
+    const json = await result.json();
+
+    const status = result.status;
+    const response = route.responses[status];
+
     return {
-      status: result.status,
-      body: await result.json(),
+      status,
+      body:
+        response && typeof response !== 'symbol' && 'parse' in response
+          ? response?.parse(json)
+          : json,
       headers: result.headers,
     };
   }
@@ -157,7 +166,7 @@ export const fetchApi = ({
   extraInputArgs,
   headers,
   signal,
-  next
+  next,
 }: {
   path: string;
   clientArgs: ClientArgs;
@@ -243,21 +252,31 @@ export const getCompleteUrl = (
   return `${baseUrl}${path}${queryComponent}`;
 };
 
-export const getRouteQuery = <TAppRoute extends AppRoute, Framework extends Frameworks = 'none'>(
+export const getRouteQuery = <
+  TAppRoute extends AppRoute,
+  Framework extends Frameworks = 'none'
+>(
   route: TAppRoute,
-  clientArgs: InitClientArgs,
+  clientArgs: InitClientArgs
 ) => {
   const knownResponseStatuses = Object.keys(route.responses);
   return async (
-    inputArgs?: Framework extends 'nextjs' ? 
-      ClientInferRequest<AppRouteMutation, ClientArgs, 'nextjs'> 
+    inputArgs?: Framework extends 'nextjs'
+      ? ClientInferRequest<AppRouteMutation, ClientArgs, 'nextjs'>
       : ClientInferRequest<AppRouteMutation, ClientArgs>
   ) => {
-    const { query, params, body, headers, extraHeaders, next, ...extraInputArgs } =
+    const {
+      query,
+      params,
+      body,
+      headers,
+      extraHeaders,
+      next,
+      ...extraInputArgs
+    } =
       // ---- Merge all framework Request infer types ----
-      inputArgs as ClientInferRequest<AppRouteMutation, ClientArgs, 'nextjs'> &
-        ClientInferRequest<AppRouteMutation, ClientArgs>
-      || {};
+      (inputArgs as ClientInferRequest<AppRouteMutation, ClientArgs, 'nextjs'> &
+        ClientInferRequest<AppRouteMutation, ClientArgs>) || {};
 
     const completeUrl = getCompleteUrl(
       query,

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -107,17 +107,24 @@ export const tsRestFetchApi: ApiFetcher = async ({
   const contentType = result.headers.get('content-type');
 
   if (contentType?.includes('application/') && contentType?.includes('json')) {
-    const json = await result.json();
+    if (!route.validateResponseOnClient) {
+      return {
+        status: result.status,
+        body: await result.json(),
+        headers: result.headers,
+      };
+    }
 
-    const status = result.status;
-    const response = route.responses[status];
+    const jsonData = await result.json();
+    const statusCode = result.status;
+    const response = route.responses[statusCode];
 
     return {
-      status,
+      status: statusCode,
       body:
         response && typeof response !== 'symbol' && 'parse' in response
-          ? response?.parse(json)
-          : json,
+          ? response?.parse(jsonData)
+          : jsonData,
       headers: result.headers,
     };
   }

--- a/libs/ts-rest/core/src/lib/dsl.ts
+++ b/libs/ts-rest/core/src/lib/dsl.ts
@@ -15,7 +15,7 @@ declare const NullSymbol: unique symbol;
 export type ContractPlainType<T> = Opaque<T, 'ContractPlainType'>;
 export type ContractNullType = Opaque<typeof NullSymbol, 'ContractNullType'>;
 export type ContractAnyType =
-  | z.ZodTypeAny
+  | z.ZodSchema
   | ContractPlainType<unknown>
   | ContractNullType
   | null;

--- a/libs/ts-rest/core/src/lib/dsl.ts
+++ b/libs/ts-rest/core/src/lib/dsl.ts
@@ -38,6 +38,7 @@ type AppRouteCommon = {
   >;
   strictStatusCodes?: boolean;
   metadata?: unknown;
+  validateResponseOnClient?: boolean;
 };
 
 /**
@@ -152,6 +153,7 @@ export type RouterOptions<TPrefix extends string = string> = {
   baseHeaders?: unknown;
   strictStatusCodes?: boolean;
   pathPrefix?: TPrefix;
+  validateResponseOnClient?: boolean;
 };
 
 /**


### PR DESCRIPTION
Addresses #306.

I'm not sure how you'd want testing to be approached for this, as such it's being left open-ended.
The current test suite run using `pnpm build-test-all` executes all the tests successfully.

Overview of changes: 
* Added an optional `boolean` field named `validateResponseOnClient` to the `AppRouteCommon` and `RouterOptions` interfaces to allow for conditional route or router-based response validation.
* Changed the type of `z.ZodTypeAny` to `z.ZodSchema` on `ContactAnyType`.
* Added runtime validation for `application/json` responses to the `tsRestFetchApi`.
