### PR TITLE
fix: release action fix by reverting to older @nx/rollup version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/platform-express": "10.1.2",
     "@nestjs/platform-fastify": "10.1.2",
     "@nestjs/swagger": "7.1.4",
-    "@nx/rollup": "16.7.4",
+    "@nx/rollup": "16.5.5",
     "@prisma/client": "^4.5.0",
     "@react-navigation/native": "^6.0.13",
     "@react-navigation/stack": "^6.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: 7.1.4
         version: 7.1.4(@nestjs/common@10.1.2)(@nestjs/core@10.1.2)(reflect-metadata@0.1.13)
       '@nx/rollup':
-        specifier: 16.7.4
-        version: 16.7.4(@babel/core@7.19.1)(@swc/core@1.3.62)(@types/node@18.11.9)(nx@16.7.4)(ts-node@10.9.1)(typescript@5.2.2)
+        specifier: 16.5.5
+        version: 16.5.5(@babel/core@7.19.1)(@swc/core@1.3.62)(nx@16.7.4)(ts-node@10.9.1)(typescript@5.2.2)
       '@prisma/client':
         specifier: ^4.5.0
         version: 4.5.0(prisma@4.5.0)
@@ -7992,7 +7992,7 @@ packages:
       '@jest/schemas': 29.6.0
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.4.10
+      '@types/node': 18.11.9
       '@types/yargs': 17.0.12
       chalk: 4.1.2
 
@@ -8620,12 +8620,29 @@ packages:
       - typescript
     dev: true
 
+  /@nrwl/devkit@16.5.5(nx@16.5.5):
+    resolution: {integrity: sha512-4ho9Vfg1YzRYZ4SMygYI9Yz1avpujd81gy/Um2Z0q8Q7Twp6Q/uG1KY9Hb7EzVXgrRcgGWdIPXuw41DpmnfWug==}
+    dependencies:
+      '@nx/devkit': 16.5.5(nx@16.5.5)
+    transitivePeerDependencies:
+      - nx
+    dev: false
+
+  /@nrwl/devkit@16.5.5(nx@16.7.4):
+    resolution: {integrity: sha512-4ho9Vfg1YzRYZ4SMygYI9Yz1avpujd81gy/Um2Z0q8Q7Twp6Q/uG1KY9Hb7EzVXgrRcgGWdIPXuw41DpmnfWug==}
+    dependencies:
+      '@nx/devkit': 16.5.5(nx@16.7.4)
+    transitivePeerDependencies:
+      - nx
+    dev: false
+
   /@nrwl/devkit@16.7.4(nx@16.7.4):
     resolution: {integrity: sha512-Gt2q3cqDWzGP1woavGIo4bl8g9YaXic/Xfsl7qPq0LHJedLj49p1vXetB0wawkavSE2MTyo7yDh6YDK/38XoLw==}
     dependencies:
       '@nx/devkit': 16.7.4(nx@16.7.4)
     transitivePeerDependencies:
       - nx
+    dev: true
 
   /@nrwl/eslint-plugin-nx@16.7.4(@swc/core@1.3.62)(@types/node@18.11.9)(@typescript-eslint/parser@5.62.0)(eslint-config-prettier@8.5.0)(eslint@8.46.0)(nx@16.7.4)(typescript@5.2.2):
     resolution: {integrity: sha512-/qN/Gn0f+7fxmxLO/mSacous3fkBXCeauKKIeJQl6uSi1aVhV/u4BddNK+d2zn5WNN/xBI+xZThM+DYJMsiXjA==}
@@ -8752,6 +8769,21 @@ packages:
       - verdaccio
     dev: true
 
+  /@nrwl/js@16.5.5(@swc/core@1.3.62)(nx@16.7.4)(typescript@5.2.2):
+    resolution: {integrity: sha512-tLHhRrljgctf/RWcqMoPGoE9Wvrr34QDFrO0LwEYx2gNufco7xp5hNb5CZtwbFjVNoynK3/aafjnh3blbt+VXA==}
+    dependencies:
+      '@nx/js': 16.5.5(@swc/core@1.3.62)(nx@16.7.4)(typescript@5.2.2)
+    transitivePeerDependencies:
+      - '@babel/traverse'
+      - '@swc-node/register'
+      - '@swc/core'
+      - debug
+      - nx
+      - supports-color
+      - typescript
+      - verdaccio
+    dev: false
+
   /@nrwl/js@16.7.4(@swc/core@1.3.62)(@types/node@18.11.9)(nx@16.7.4)(typescript@5.2.2):
     resolution: {integrity: sha512-7mQnzhUUSpMOnSxM10Q2XOWWEj+GdtV7HVt1s+LDvRVXSFNLWBOucjfBunbttYGO36aKk+ZPCU53SvwH2aL5eA==}
     dependencies:
@@ -8767,6 +8799,7 @@ packages:
       - supports-color
       - typescript
       - verdaccio
+    dev: true
 
   /@nrwl/linter@14.8.8(@swc/core@1.3.62)(@types/node@18.11.9)(eslint@8.46.0)(ts-node@10.9.1)(typescript@5.2.2):
     resolution: {integrity: sha512-Siu4KogGRJpESVgWqv1mXM28aqs7e/Uerb4miaSflCfXAhJo7kbsALfDOomhqubvGyE5r4dyorLMtVPbZA5iFg==}
@@ -8902,18 +8935,16 @@ packages:
       - webpack
     dev: true
 
-  /@nrwl/rollup@16.7.4(@babel/core@7.19.1)(@swc/core@1.3.62)(@types/node@18.11.9)(nx@16.7.4)(ts-node@10.9.1)(typescript@5.2.2):
-    resolution: {integrity: sha512-XCbQzhmvARwlMGDTJuJys7X4t+wFffVqjj1P8NZ3pkbfMq3J9Qehll0Uo4236pjtYE1AyyWdA2eCG7MUPNxP0A==}
+  /@nrwl/rollup@16.5.5(@babel/core@7.19.1)(@swc/core@1.3.62)(nx@16.7.4)(ts-node@10.9.1)(typescript@5.2.2):
+    resolution: {integrity: sha512-Eli96d4IDId84VIxQ2D8jezYTF/Bkdl1y0ds1fF60WJ8Gv/g27o4ZeTF8q+kN0VXlazwdcBVO4I2nhaEovRXkQ==}
     dependencies:
-      '@nx/rollup': 16.7.4(@babel/core@7.19.1)(@swc/core@1.3.62)(@types/node@18.11.9)(nx@16.7.4)(ts-node@10.9.1)(typescript@5.2.2)
+      '@nx/rollup': 16.5.5(@babel/core@7.19.1)(@swc/core@1.3.62)(nx@16.7.4)(ts-node@10.9.1)(typescript@5.2.2)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
-      - '@swc/wasm'
       - '@types/babel__core'
-      - '@types/node'
       - debug
       - nx
       - supports-color
@@ -8932,6 +8963,17 @@ packages:
       - '@swc/core'
       - debug
     dev: true
+
+  /@nrwl/tao@16.5.5(@swc/core@1.3.62):
+    resolution: {integrity: sha512-6SYG3rlKkYvy/wauPwoUXQuN0PTJi95hCEC7lGfCEGye2Y/61UwJQf2xixMxafUM2X84WdEStEz3Jty85gVqkQ==}
+    hasBin: true
+    dependencies:
+      nx: 16.5.5(@swc/core@1.3.62)
+    transitivePeerDependencies:
+      - '@swc-node/register'
+      - '@swc/core'
+      - debug
+    dev: false
 
   /@nrwl/tao@16.7.4(@swc/core@1.3.62):
     resolution: {integrity: sha512-hH03oF+yVmaf19UZfyLDSuVEh0KasU5YfYezuNsdRkXNdTU/WmpDrk4qoo0j6fVoMPrqbbPOn1YMRtulP2WyYA==}
@@ -9058,6 +9100,16 @@ packages:
       - typescript
     dev: true
 
+  /@nrwl/workspace@16.5.5(@swc/core@1.3.62):
+    resolution: {integrity: sha512-BEoqLqll82US8ACcSPGhOWaCVYNt77dSH4J4iounvC9ADO2CdbZT06MtC+ivMxJ1DpZZywXWOwhmEWqXIeU5ig==}
+    dependencies:
+      '@nx/workspace': 16.5.5(@swc/core@1.3.62)
+    transitivePeerDependencies:
+      - '@swc-node/register'
+      - '@swc/core'
+      - debug
+    dev: false
+
   /@nrwl/workspace@16.7.4(@swc/core@1.3.62):
     resolution: {integrity: sha512-i2mMSzF/qfsFbTD0DBMSRTNKSahJZoJCnDrTSgwZeTVfLoKYOO5QaiAqB0zKh/5qTsBCt/rKtAlfTd5uGpBzPQ==}
     dependencies:
@@ -9066,6 +9118,7 @@ packages:
       - '@swc-node/register'
       - '@swc/core'
       - debug
+    dev: true
 
   /@nuxtjs/opencollective@0.3.2:
     resolution: {integrity: sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==}
@@ -9152,6 +9205,34 @@ packages:
       - webpack
     dev: true
 
+  /@nx/devkit@16.5.5(nx@16.5.5):
+    resolution: {integrity: sha512-9YaQ3s5VMgTXo5cEuaVc2b6btZU2REmHsgn/V4Gi3nSmwBHvIn86gtlh4BoBFinHpqge1chG/dC+B7yoXioQmQ==}
+    peerDependencies:
+      nx: '>= 15 <= 17'
+    dependencies:
+      '@nrwl/devkit': 16.5.5(nx@16.5.5)
+      ejs: 3.1.8
+      ignore: 5.2.4
+      nx: 16.5.5(@swc/core@1.3.62)
+      semver: 7.5.3
+      tmp: 0.2.1
+      tslib: 2.6.1
+    dev: false
+
+  /@nx/devkit@16.5.5(nx@16.7.4):
+    resolution: {integrity: sha512-9YaQ3s5VMgTXo5cEuaVc2b6btZU2REmHsgn/V4Gi3nSmwBHvIn86gtlh4BoBFinHpqge1chG/dC+B7yoXioQmQ==}
+    peerDependencies:
+      nx: '>= 15 <= 17'
+    dependencies:
+      '@nrwl/devkit': 16.5.5(nx@16.7.4)
+      ejs: 3.1.8
+      ignore: 5.2.4
+      nx: 16.7.4(@swc/core@1.3.62)
+      semver: 7.5.3
+      tmp: 0.2.1
+      tslib: 2.6.1
+    dev: false
+
   /@nx/devkit@16.7.4(nx@16.7.4):
     resolution: {integrity: sha512-SLito+/TAeDYR+d7IIpp/sBJm41WM+nIevILv0TSQW4Pq0ylUy1nUvV8Pe7l1ohZccDrQuebMUWPwGO0hv8SeQ==}
     peerDependencies:
@@ -9165,6 +9246,7 @@ packages:
       semver: 7.5.3
       tmp: 0.2.1
       tslib: 2.6.1
+    dev: true
 
   /@nx/eslint-plugin@16.7.4(@swc/core@1.3.62)(@types/node@18.11.9)(@typescript-eslint/parser@5.62.0)(eslint-config-prettier@8.5.0)(eslint@8.46.0)(nx@16.7.4)(typescript@5.2.2):
     resolution: {integrity: sha512-PjpXeW/Tr/y/PJSEaB9X2xNaqW6mYXzcFSAXQrlxuDNdVEtrieSj+OiAGKfaYjkcN1d/X9dupV6b/L0V+HcSlw==}
@@ -9324,6 +9406,48 @@ packages:
       - verdaccio
     dev: true
 
+  /@nx/js@16.5.5(@swc/core@1.3.62)(nx@16.7.4)(typescript@5.2.2):
+    resolution: {integrity: sha512-pJaCmPiRnN/lnH9VsIzS1Qlpe2p14dNGgXfkonbflMr8qtzqT5izwBrojQYtUlhV6hAXuacT8AdUZlgK+y/d3g==}
+    peerDependencies:
+      verdaccio: ^5.0.4
+    peerDependenciesMeta:
+      verdaccio:
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.9)
+      '@babel/plugin-proposal-decorators': 7.22.10(@babel/core@7.22.9)
+      '@babel/plugin-transform-runtime': 7.22.10(@babel/core@7.22.9)
+      '@babel/preset-env': 7.22.10(@babel/core@7.22.9)
+      '@babel/preset-typescript': 7.22.5(@babel/core@7.22.9)
+      '@babel/runtime': 7.22.10
+      '@nrwl/js': 16.5.5(@swc/core@1.3.62)(nx@16.7.4)(typescript@5.2.2)
+      '@nx/devkit': 16.5.5(nx@16.7.4)
+      '@nx/workspace': 16.5.5(@swc/core@1.3.62)
+      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.2.2)
+      babel-plugin-const-enum: 1.2.0(@babel/core@7.22.9)
+      babel-plugin-macros: 2.8.0
+      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.22.9)
+      chalk: 4.1.2
+      detect-port: 1.5.1
+      fast-glob: 3.2.7
+      fs-extra: 11.1.1
+      ignore: 5.2.4
+      js-tokens: 4.0.0
+      minimatch: 3.0.5
+      semver: 7.5.3
+      source-map-support: 0.5.19
+      tslib: 2.6.1
+    transitivePeerDependencies:
+      - '@babel/traverse'
+      - '@swc-node/register'
+      - '@swc/core'
+      - debug
+      - nx
+      - supports-color
+      - typescript
+    dev: false
+
   /@nx/js@16.7.4(@swc/core@1.3.62)(@types/node@18.11.9)(nx@16.7.4)(typescript@5.2.2):
     resolution: {integrity: sha512-aJnpJkgGgEt1IjsV/ywZRLZ4B5/jDkTtdVu+Wf+6UrtlWji7sq2PC96NSuKeEHjq3oAvNsBc8+u2rjB/9a+8jQ==}
     peerDependencies:
@@ -9368,6 +9492,7 @@ packages:
       - nx
       - supports-color
       - typescript
+    dev: true
 
   /@nx/linter@16.7.4(@swc/core@1.3.62)(@types/node@18.11.9)(eslint@8.46.0)(nx@16.7.4)(typescript@5.2.2):
     resolution: {integrity: sha512-AGuPfpDIk44fBIwcloo2Hb0+ROmoD69n6ypzdpZvRrBS6KHROGjT3SoWKituyj75bSgtWndNC1ywBhcVnRfamg==}
@@ -9494,12 +9619,30 @@ packages:
       - verdaccio
     dev: true
 
+  /@nx/nx-darwin-arm64@16.5.5:
+    resolution: {integrity: sha512-Zzwy7pkSDFTiWcBk78qDe4VzygO9kemtz/kbbLvpisZkUlZX9nIQnLHT80Ms++iqA0enIQAwdTcJiaIHLVd5JQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@nx/nx-darwin-arm64@16.7.4:
     resolution: {integrity: sha512-pRNjxn6KlcR6iGkU1j/1pzcogwXFv97pYiZaibpF7UV0vfdEUA3EETpDcs+hbNAcKMvVtn/TgN857/5LQ/lGUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    optional: true
+
+  /@nx/nx-darwin-x64@16.5.5:
+    resolution: {integrity: sha512-d5O8BD5HFI2hJnMgVVV1pl2A+hlUmn4GxCZTmx2Tr329TYGdpvyXm8NnDFEAigZ77QVMHwFN6vqS07HARu+uVA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@nx/nx-darwin-x64@16.7.4:
@@ -9510,12 +9653,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@nx/nx-freebsd-x64@16.5.5:
+    resolution: {integrity: sha512-SqTvbz21iUc8DHKgisX9pPuXc7/DngbiZxInlEHPXi8zUtyUOqZI3yQk4NVj3dqLBMLwEOZDgvXs0XxzB5nn+g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@nx/nx-freebsd-x64@16.7.4:
     resolution: {integrity: sha512-zmBBDYjPaHhIHx1YASUJJIy+oz7mCrj5f0f3kOzfMraQOjkQZ0xYgNNUzBqmnYu1855yiphu94MkAMYJnbk0jw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    optional: true
+
+  /@nx/nx-linux-arm-gnueabihf@16.5.5:
+    resolution: {integrity: sha512-8C2KVFHqcyGViEgUicYo1frEgQARbD+CicIos6A5WRYLaxS+upb9FDblKU0eGYIwDp8oCagVjUjNX8d1WHLX7w==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@nx/nx-linux-arm-gnueabihf@16.7.4:
@@ -9526,12 +9687,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@nx/nx-linux-arm64-gnu@16.5.5:
+    resolution: {integrity: sha512-AGq4wp3Wn8bE0h2c7/bHj2wQWfp08DYJemwTNLkwLcoJWkUidLOBQePRvLxqPeo42Zmt3GYMi+fi5XtKCmvcjg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@nx/nx-linux-arm64-gnu@16.7.4:
     resolution: {integrity: sha512-W1u4O78lTHCwvUP0vakeKWFXeSZ13nYzbd6FARICnImY2my8vz41rLm6aU9TYWaiOGEGL2xKpHKSgiNwbLjhFw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@nx/nx-linux-arm64-musl@16.5.5:
+    resolution: {integrity: sha512-xPTYjDCPnXLPXZThAzugiithZaIHk42rTxussMZA00Cx0iEkh5zohqtC0vGBnaAPNcMv0uyCiWABhL4RRUVp2w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@nx/nx-linux-arm64-musl@16.7.4:
@@ -9542,12 +9721,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@nx/nx-linux-x64-gnu@16.5.5:
+    resolution: {integrity: sha512-Rq55OWD4SObfo4sWpjvaijWg33dm+cOf8e2cO06t2EmLMdOyyVnpNdtpjXh6A9tSi3EU5xPfYiy3I9O6gWOnuw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@nx/nx-linux-x64-gnu@16.7.4:
     resolution: {integrity: sha512-4B58C/pXeuovSznBOeicsxNieBApbGMoi2du8jR6Is1gYFPv4l8fFHQHHGAa1l5XJC5JuGJqFywS4elInWprNw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@nx/nx-linux-x64-musl@16.5.5:
+    resolution: {integrity: sha512-fnkSPv+VIKmQQOEQxFrGx5DlkHGxeH9Fzme6jwuDwmsvs+8Vv/uUnfcxkDZfJxKK+p27w37q3PQCfZGrFXE1cw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@nx/nx-linux-x64-musl@16.7.4:
@@ -9558,12 +9755,30 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@nx/nx-win32-arm64-msvc@16.5.5:
+    resolution: {integrity: sha512-9nWm+d+tlbxFMLvTLJqIfpTLDuSVDXfSBCSBampyeoI1mUALvq/6CVvWVBDlNqjmrZsYm0sudNqI4Ss7w3BUCQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@nx/nx-win32-arm64-msvc@16.7.4:
     resolution: {integrity: sha512-etNnbuCcSqAYOeDcS6si6qw0WR/IS87ovTzLS17ETKpdHcHN5nM4l02CQyupKiD58ShxrXHxXmvgBfbXxoN5Ew==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    optional: true
+
+  /@nx/nx-win32-x64-msvc@16.5.5:
+    resolution: {integrity: sha512-fB8miPr887GIGBDhyT6VX7MWX5aC40izEi+4GGSk38oh5dOUK9TLwjAEW/3vBE01fj5Hjcy0CPN7RA45fh/WUw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@nx/nx-win32-x64-msvc@16.7.4:
@@ -9603,12 +9818,12 @@ packages:
       - webpack
     dev: true
 
-  /@nx/rollup@16.7.4(@babel/core@7.19.1)(@swc/core@1.3.62)(@types/node@18.11.9)(nx@16.7.4)(ts-node@10.9.1)(typescript@5.2.2):
-    resolution: {integrity: sha512-SWpX/aPkh45Trv326CnX8DGV2gZGX3eeVGTgo9YrDVMfAfZebtCarFDTOu8pFCjgHDhb/XEZo500HGuaqesnZQ==}
+  /@nx/rollup@16.5.5(@babel/core@7.19.1)(@swc/core@1.3.62)(nx@16.7.4)(ts-node@10.9.1)(typescript@5.2.2):
+    resolution: {integrity: sha512-C16BWkNBDWX8581EGXBIwEl0DmJ9BSSX79vhJGrVlq0uwQMPWwRm6MrEpAzqiiO70fztKvYFAGGAyJGEKwUR2Q==}
     dependencies:
-      '@nrwl/rollup': 16.7.4(@babel/core@7.19.1)(@swc/core@1.3.62)(@types/node@18.11.9)(nx@16.7.4)(ts-node@10.9.1)(typescript@5.2.2)
-      '@nx/devkit': 16.7.4(nx@16.7.4)
-      '@nx/js': 16.7.4(@swc/core@1.3.62)(@types/node@18.11.9)(nx@16.7.4)(typescript@5.2.2)
+      '@nrwl/rollup': 16.5.5(@babel/core@7.19.1)(@swc/core@1.3.62)(nx@16.7.4)(ts-node@10.9.1)(typescript@5.2.2)
+      '@nx/devkit': 16.5.5(nx@16.7.4)
+      '@nx/js': 16.5.5(@swc/core@1.3.62)(nx@16.7.4)(typescript@5.2.2)
       '@rollup/plugin-babel': 5.3.1(@babel/core@7.19.1)(rollup@2.79.0)
       '@rollup/plugin-commonjs': 20.0.0(rollup@2.79.0)
       '@rollup/plugin-image': 2.1.1(rollup@2.79.0)
@@ -9617,8 +9832,7 @@ packages:
       autoprefixer: 10.4.13(postcss@8.4.19)
       babel-plugin-transform-async-to-promises: 0.8.18
       chalk: 4.1.2
-      dotenv: 16.3.1
-      fast-glob: 3.2.12
+      dotenv: 10.0.0
       postcss: 8.4.19
       rollup: 2.79.0
       rollup-plugin-copy: 3.4.0
@@ -9632,9 +9846,7 @@ packages:
       - '@babel/traverse'
       - '@swc-node/register'
       - '@swc/core'
-      - '@swc/wasm'
       - '@types/babel__core'
-      - '@types/node'
       - debug
       - nx
       - supports-color
@@ -9767,6 +9979,35 @@ packages:
       - webpack-cli
     dev: true
 
+  /@nx/workspace@16.5.5(@swc/core@1.3.62):
+    resolution: {integrity: sha512-fg+mvdIW4X+5fUMn/X3HEU7r6T2o7/iMQFkcbY+NUGpgL+/bPMvN5mrh5ptwBZwVRgjKwOj3U+CwhKHUQLB80w==}
+    dependencies:
+      '@nrwl/workspace': 16.5.5(@swc/core@1.3.62)
+      '@nx/devkit': 16.5.5(nx@16.5.5)
+      '@parcel/watcher': 2.0.4
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      cli-cursor: 3.1.0
+      cli-spinners: 2.6.1
+      dotenv: 10.0.0
+      figures: 3.2.0
+      flat: 5.0.2
+      ignore: 5.2.4
+      minimatch: 3.0.5
+      npm-run-path: 4.0.1
+      nx: 16.5.5(@swc/core@1.3.62)
+      open: 8.4.0
+      rxjs: 7.8.1
+      tmp: 0.2.1
+      tslib: 2.6.1
+      yargs: 17.6.2
+      yargs-parser: 21.1.1
+    transitivePeerDependencies:
+      - '@swc-node/register'
+      - '@swc/core'
+      - debug
+    dev: false
+
   /@nx/workspace@16.7.4(@swc/core@1.3.62):
     resolution: {integrity: sha512-mbefKyHg3avgK1jN6GChCDz2wc1qvi22BOUd/4WO+o88sShAA2h0gg8SMvkzLTNvGcNUWok66dInBfAJHvUOnw==}
     dependencies:
@@ -9782,6 +10023,7 @@ packages:
       - '@swc-node/register'
       - '@swc/core'
       - debug
+    dev: true
 
   /@oclif/core@1.23.2:
     resolution: {integrity: sha512-NdaOaUDTRc6g1yTkOAKiEVOiQhc5CNcWNXa0QF4IS4yTjNqp4DOzgtF9Dwe585nPEKzSbTBiz1wyLOa4qIHSRQ==}
@@ -10773,7 +11015,7 @@ packages:
     dependencies:
       '@svgr/core': 6.3.1
       cosmiconfig: 7.0.1
-      deepmerge: 4.2.2
+      deepmerge: 4.3.1
       svgo: 2.8.0
     dev: false
 
@@ -11351,7 +11593,7 @@ packages:
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 20.4.10
+      '@types/node': 18.11.9
 
   /@types/cookiejar@2.1.2:
     resolution: {integrity: sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==}
@@ -16756,7 +16998,6 @@ packages:
   /dotenv@10.0.0:
     resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
     engines: {node: '>=10'}
-    dev: true
 
   /dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
@@ -24167,6 +24408,69 @@ packages:
       - debug
     dev: true
 
+  /nx@16.5.5(@swc/core@1.3.62):
+    resolution: {integrity: sha512-DHwoUtkirI52JIlCtRK78UI/Ik/VgCtM6FlkfPnFsy8PVyTYMQ40KoG6aZLHjqj5qxoGG2CUjcsbFjGXYrjDbw==}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@swc-node/register': ^1.4.2
+      '@swc/core': ^1.2.173
+    peerDependenciesMeta:
+      '@swc-node/register':
+        optional: true
+      '@swc/core':
+        optional: true
+    dependencies:
+      '@nrwl/tao': 16.5.5(@swc/core@1.3.62)
+      '@parcel/watcher': 2.0.4
+      '@swc/core': 1.3.62(@swc/helpers@0.5.1)
+      '@yarnpkg/lockfile': 1.1.0
+      '@yarnpkg/parsers': 3.0.0-rc.46
+      '@zkochan/js-yaml': 0.0.6
+      axios: 1.1.3
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.6.1
+      cliui: 7.0.4
+      dotenv: 10.0.0
+      enquirer: 2.3.6
+      fast-glob: 3.2.7
+      figures: 3.2.0
+      flat: 5.0.2
+      fs-extra: 11.1.1
+      glob: 7.1.4
+      ignore: 5.2.4
+      js-yaml: 4.1.0
+      jsonc-parser: 3.2.0
+      lines-and-columns: 2.0.3
+      minimatch: 3.0.5
+      npm-run-path: 4.0.1
+      open: 8.4.0
+      semver: 7.5.3
+      string-width: 4.2.3
+      strong-log-transformer: 2.1.0
+      tar-stream: 2.2.0
+      tmp: 0.2.1
+      tsconfig-paths: 4.2.0
+      tslib: 2.6.1
+      v8-compile-cache: 2.3.0
+      yargs: 17.6.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@nx/nx-darwin-arm64': 16.5.5
+      '@nx/nx-darwin-x64': 16.5.5
+      '@nx/nx-freebsd-x64': 16.5.5
+      '@nx/nx-linux-arm-gnueabihf': 16.5.5
+      '@nx/nx-linux-arm64-gnu': 16.5.5
+      '@nx/nx-linux-arm64-musl': 16.5.5
+      '@nx/nx-linux-x64-gnu': 16.5.5
+      '@nx/nx-linux-x64-musl': 16.5.5
+      '@nx/nx-win32-arm64-msvc': 16.5.5
+      '@nx/nx-win32-x64-msvc': 16.5.5
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /nx@16.7.4(@swc/core@1.3.62):
     resolution: {integrity: sha512-L0Cbikk5kO+IBH0UQ2BOAut5ndeHXBlACKzjOPOCluY8WYh2sxWYt9/N/juFBN3XXRX7ionTr1PhWUzNE0Mzqw==}
     hasBin: true
@@ -28509,6 +28813,7 @@ packages:
 
   /sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    deprecated: Please use @jridgewell/sourcemap-codec instead
 
   /space-separated-tokens@1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}


### PR DESCRIPTION
For some reason, any version of `@nx/rollup` higher than 16.5.5 seems to break our CI by outputting compiled files as `cjs` instead of `js`. 


This is a temporary workaround to unblock releases until a long term strategy is figured out. 

https://github.com/nrwl/nx/issues/18912