### PR TITLE
fix: remove console log from fastify route initialization

### DIFF
--- a/.changeset/great-clouds-teach.md
+++ b/.changeset/great-clouds-teach.md
@@ -2,4 +2,4 @@
 '@ts-rest/fastify': patch
 ---
 
-Remove unintentional console log in fasitfy route initialization
+Remove unintentional console log in fasitfy route initialization for `@ts-rest/fastify`

--- a/.changeset/great-clouds-teach.md
+++ b/.changeset/great-clouds-teach.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/fastify': patch
+---
+
+Remove unintentional console log in fasitfy route initialization

--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
@@ -269,8 +269,6 @@ const recursivelyRegisterRouter = <T extends AppRouter>(
   options: RegisterRouterOptions
 ) => {
   if (typeof routerImpl === 'object') {
-    console.log(routerImpl);
-
     if (implementationIsInitialisedRouter(routerImpl)) {
       recursivelyRegisterRouter(
         routerImpl.routes,


### PR DESCRIPTION
<img width="603" alt="Screenshot 2023-08-31 at 10 48 58" src="https://github.com/ts-rest/ts-rest/assets/47489826/8d14e1bf-d9e5-4f52-933d-ae8930197e13">

Spotted using on a fastify app