### PR TITLE
fix: content-type application/json behavior for client

### DIFF
--- a/.changeset/popular-ants-relax.md
+++ b/.changeset/popular-ants-relax.md
@@ -1,0 +1,6 @@
+---
+'@ts-rest/core': patch
+'@ts-rest/vue-query': patch
+---
+
+fix: content-type application/json will not be automatically included in client request if the route is GET or body is undefined/null

--- a/apps/example-next/tests/react-query.spec.tsx
+++ b/apps/example-next/tests/react-query.spec.tsx
@@ -184,7 +184,6 @@ describe('react-query', () => {
       path: 'https://api.com/health',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.health,
@@ -225,7 +224,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -298,7 +296,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -325,7 +322,6 @@ describe('react-query', () => {
       path: 'https://api.com/health',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.health,
@@ -358,7 +354,6 @@ describe('react-query', () => {
       path: 'https://api.com/health',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.health,
@@ -468,7 +463,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -480,7 +474,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/2',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -541,7 +534,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -553,7 +545,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/2',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -618,7 +609,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -630,7 +620,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/2',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -673,7 +662,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -703,7 +691,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -739,7 +726,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -769,7 +755,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -816,7 +801,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -225,9 +225,6 @@ describe('client', () => {
       fetchMock.getOnce(
         {
           url: 'https://api.com/posts',
-          headers: {
-            'Content-Type': 'application/json',
-          },
         },
         { body: value, status: 200 }
       );
@@ -245,9 +242,6 @@ describe('client', () => {
       fetchMock.getOnce(
         {
           url: 'https://api.com/posts',
-          headers: {
-            'Content-Type': 'application/json',
-          },
         },
         { body: value, status: 200 }
       );
@@ -265,9 +259,6 @@ describe('client', () => {
       fetchMock.getOnce(
         {
           url: 'https://api.com/posts',
-          headers: {
-            'Content-Type': 'application/json',
-          },
         },
         { body: value, status: 200 }
       );
@@ -285,9 +276,6 @@ describe('client', () => {
       fetchMock.getOnce(
         {
           url: 'https://api.com/posts?take=10',
-          headers: {
-            'Content-Type': 'application/json',
-          },
         },
         { body: value, status: 200 }
       );
@@ -326,9 +314,6 @@ describe('client', () => {
           url: `https://api.com/posts?take=10&order=asc&published=true&filter=${encodeURIComponent(
             '{"title":"test"}'
           )}`,
-          headers: {
-            'Content-Type': 'application/json',
-          },
         },
         { body: value, status: 200 }
       );
@@ -354,9 +339,6 @@ describe('client', () => {
       fetchMock.getOnce(
         {
           url: 'https://api.com/posts?take=10',
-          headers: {
-            'Content-Type': 'application/json',
-          },
         },
         { body: value, status: 200 }
       );
@@ -368,7 +350,6 @@ describe('client', () => {
       expect(result.body).toStrictEqual(value);
       expect(result.status).toBe(200);
       expect(result.headers.get('Content-Length')).toBe('15');
-      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
 
     it('w/ sub path', async () => {
@@ -376,9 +357,6 @@ describe('client', () => {
       fetchMock.getOnce(
         {
           url: 'https://api.com/posts/1',
-          headers: {
-            'Content-Type': 'application/json',
-          },
         },
         { body: value, status: 200 }
       );
@@ -388,16 +366,12 @@ describe('client', () => {
       expect(result.body).toStrictEqual(value);
       expect(result.status).toBe(200);
       expect(result.headers.get('Content-Length')).toBe('15');
-      expect(result.headers.get('Content-Type')).toBe('application/json');
     });
 
     it('w/ a non json response (string)', async () => {
       fetchMock.getOnce(
         {
           url: 'https://api.com/posts',
-          headers: {
-            'Content-Type': 'application/json',
-          },
         },
         {
           headers: {
@@ -500,9 +474,6 @@ describe('client', () => {
       fetchMock.patchOnce(
         {
           url: 'https://api.com/posts/1',
-          headers: {
-            'Content-Type': 'application/json',
-          },
         },
         { body: value, status: 200 }
       );
@@ -524,9 +495,6 @@ describe('client', () => {
       fetchMock.deleteOnce(
         {
           url: 'https://api.com/posts/1',
-          headers: {
-            'Content-Type': 'application/json',
-          },
         },
         { body: value, status: 200 }
       );
@@ -713,7 +681,6 @@ describe('custom api', () => {
         headers: {
           'base-header': 'foo',
           'x-test': 'test',
-          'content-type': 'application/json',
         },
       })
     );

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -227,7 +227,7 @@ export const fetchApi = ({
     method: route.method,
     credentials: clientArgs.credentials,
     headers: {
-      'content-type': 'application/json',
+      ...(body !== null && body !== undefined && { 'content-type': 'application/json' }),
       ...combinedHeaders,
     },
     body:

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -221,20 +221,23 @@ export const fetchApi = ({
     });
   }
 
+  const includeContentTypeHeader =
+    route.method !== 'GET' && body !== null && body !== undefined;
+
   return apiFetcher({
     route,
     path,
     method: route.method,
     credentials: clientArgs.credentials,
     headers: {
-      ...(body !== null && body !== undefined && { 'content-type': 'application/json' }),
+      ...(includeContentTypeHeader ? { 'content-type': 'application/json' } : {}),
       ...combinedHeaders,
     },
     body:
       body !== null && body !== undefined ? JSON.stringify(body) : undefined,
     rawBody: body,
     rawQuery: query,
-    contentType: route.method !== 'GET' ? 'application/json' : undefined,
+    contentType: includeContentTypeHeader ? 'application/json' : undefined,
     signal,
     next,
     ...extraInputArgs,

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -230,7 +230,7 @@ export const fetchApi = ({
     method: route.method,
     credentials: clientArgs.credentials,
     headers: {
-      ...(includeContentTypeHeader ? { 'content-type': 'application/json' } : {}),
+      ...(includeContentTypeHeader && { 'content-type': 'application/json' }),
       ...combinedHeaders,
     },
     body:

--- a/libs/ts-rest/core/src/lib/fetch.spec.ts
+++ b/libs/ts-rest/core/src/lib/fetch.spec.ts
@@ -1,0 +1,106 @@
+import * as clientModule from './client';
+import { initContract } from './dsl';
+const c = initContract();
+describe('fetchApi', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  it('should not include content-type application/json if body is undefined', async () => {
+    const tsRestApiStub = jest
+      .spyOn(clientModule, 'tsRestFetchApi')
+      .mockResolvedValue({
+        status: 200,
+        body: { message: 'never gonna give you up, never gonna let you down' },
+        headers: new Headers(),
+      });
+    await clientModule.fetchApi({
+      body: undefined,
+      headers: {},
+      path: '/rick-astley',
+      clientArgs: {
+        baseUrl: 'https://api.com',
+        baseHeaders: {},
+      },
+      route: {
+        method: 'POST',
+        body: null,
+        path: '/rick-astley',
+        responses: {
+          200: c.response<{ message: string }>(),
+        },
+      },
+      query: {},
+      extraInputArgs: {},
+    });
+    expect(tsRestApiStub).toHaveBeenCalledWith({
+      body: undefined,
+      contentType: undefined,
+      credentials: undefined,
+      headers: {},
+      method: 'POST',
+      next: undefined,
+      path: '/rick-astley',
+      rawBody: undefined,
+      rawQuery: {},
+      route: {
+        body: null,
+        method: 'POST',
+        path: '/rick-astley',
+        responses: {
+          '200': expect.anything(),
+        },
+      },
+      signal: undefined,
+    });
+  });
+
+  it('should include content-type application/json if body is defined', async () => {
+    const tsRestApiStub = jest
+      .spyOn(clientModule, 'tsRestFetchApi')
+      .mockResolvedValue({
+        status: 200,
+        body: { message: 'never gonna give you up, never gonna let you down' },
+        headers: new Headers(),
+      });
+    await clientModule.fetchApi({
+      body: {
+        message: 'never gonna say goodbye, never gonna tell a lie and hurt you',
+      },
+      headers: {},
+      path: '/rick-astley',
+      clientArgs: {
+        baseUrl: 'https://api.com',
+        baseHeaders: {},
+      },
+      route: {
+        method: 'POST',
+        body: null,
+        path: '/rick-astley',
+        responses: {
+          200: c.response<{ message: string }>(),
+        },
+      },
+      query: {},
+      extraInputArgs: {},
+    });
+    expect(tsRestApiStub).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: '{"message":"never gonna say goodbye, never gonna tell a lie and hurt you"}',
+        contentType: 'application/json',
+        credentials: undefined,
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+        next: undefined,
+        path: '/rick-astley',
+        rawBody: {
+          message:
+            'never gonna say goodbye, never gonna tell a lie and hurt you',
+        },
+        rawQuery: {},
+        signal: undefined,
+      })
+    );
+  });
+});

--- a/libs/ts-rest/next/src/lib/next-client.spec.ts
+++ b/libs/ts-rest/next/src/lib/next-client.spec.ts
@@ -59,11 +59,10 @@ describe('next-client', () => {
     } as Response));
     await usersClient.getUser({ params: { id: '1' }, next: { revalidate: 1, tags: ['user1'] } });
     expect(global.fetch).toHaveBeenCalledWith('http://localhost:5002/users/1', {
+      cache: undefined,
+      headers: {},
       body: undefined,
       credentials: undefined,
-      headers: {
-        'content-type': 'application/json'
-      },
       method: 'GET',
       signal: undefined,
       next: { revalidate: 1, tags: ['user1'] }

--- a/libs/ts-rest/vue-query/src/lib/vue-query.spec.ts
+++ b/libs/ts-rest/vue-query/src/lib/vue-query.spec.ts
@@ -204,7 +204,6 @@ describe('react-query', () => {
       path: 'https://api.com/health',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.health,
@@ -245,7 +244,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -318,7 +316,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -345,7 +342,6 @@ describe('react-query', () => {
       path: 'https://api.com/health',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.health,
@@ -379,7 +375,6 @@ describe('react-query', () => {
       path: 'https://api.com/health',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.health,
@@ -489,7 +484,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -501,7 +495,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/2',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -562,7 +555,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -574,7 +566,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/2',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -639,7 +630,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -651,7 +641,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/2',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -694,7 +683,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -724,7 +712,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -760,7 +747,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -790,7 +776,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,
@@ -837,7 +822,6 @@ describe('react-query', () => {
       path: 'https://api.com/posts/1',
       body: undefined,
       headers: {
-        'content-type': 'application/json',
         'x-test': 'test',
       },
       route: router.posts.getPost,


### PR DESCRIPTION
fixes #383 

Please review: According to [this thread](https://stackoverflow.com/questions/5661596/do-i-need-a-content-type-header-for-http-get-requests), for specifying `content-type: application/json` should be _optional_ for GET requests. 

Will this be ok so long as we correctly communicate this change? 