### PR TITLE
fix: allow blob form uploads to support node 18

### DIFF
--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -148,7 +148,7 @@ const createFormData = (body: unknown) => {
   const formData = new FormData();
 
   Object.entries(body as Record<string, unknown>).forEach(([key, value]) => {
-    if (value instanceof File) {
+    if (value instanceof Blob) {
       formData.append(key, value);
     } else {
       formData.append(key, JSON.stringify(value));


### PR DESCRIPTION
This PR changes one line, changing the `instanceof File` check to `instanceof Blob` in form uploads.

This makes form uploads possible with the generated client in `node` 18. Previously it would crash and throw something like

```sh
    ReferenceError: File is not defined

      40 |               rest: Record<string, unknown> | undefined
      41 |             ]
    > 42 |             return value.call(this, {
         |                          ^
      43 |               body: { ...body, communityId },
      44 |               ...rest,
      45 |             })
```

This also improves compatibility with `node`'s `FormData`, which allows for `Blob`s to be added to `FormData`, as well as allowing you to submit forms using `node` 18.

I do see that you have [a test that uses `File` explicitly here](https://github.com/ts-rest/ts-rest/blob/984b9b5aa229eb60562e7805a3f4bc8666ed0a26/libs/ts-rest/core/src/lib/client.spec.ts#L523-L527), I don't know why that works here, maybe some `jest` settings you are using?
