### PR TITLE
Fix error due missing comma

### DIFF
--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -102,7 +102,7 @@ export const contract = c.router({
     responses: {
       201: c.type<Post>(),
     },
-    body: c.type<{title: string}>()
+    body: c.type<{title: string}>(),
     summary: 'Create a post',
   },
   getPost: {


### PR DESCRIPTION
Properties in an object should be comma-separated, here one comma is missing, leading to an error.

I add a comma to fix the error.