### PR TITLE
feat: Allow Next.js request validation through error handler

### DIFF
--- a/.changeset/purple-rules-shake.md
+++ b/.changeset/purple-rules-shake.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/next': minor
+---
+
+feat: `ts-rest/next` allow customization for zod validation errors

--- a/apps/docs/docs/next.mdx
+++ b/apps/docs/docs/next.mdx
@@ -74,6 +74,42 @@ export default createNextRouter(api, router, {
 });
 ```
 
+#### Request Validation Error Handling
+
+The default behavior when validating request schema is to return a 400 status with the corresponding ZodError.
+To customize handling of the request validation errors enable the `throwRequestValidation` option.
+This option allows you to handle the request validation error in the global `errorHandler` function.
+
+```typescript
+export default createNextRouter(api, router, {
+  throwRequestValidation: true,
+  errorHandler: (error: unknown, req: NextApiRequest, res: NextApiResponse) => {
+    if (error instanceof RequestValidationError) {
+      if (error.body !== null) {
+        return res
+          .status(400)
+          .json({ message: 'Malformed Body', errors: error.body.flatten() });
+      }
+
+      return res.status(400).json({ message: 'Bad Request' });
+    }
+  },
+});
+```
+
+```typescript
+export class RequestValidationError extends Error {
+  constructor(
+    public pathParams: z.ZodError | null,
+    public headers: z.ZodError | null,
+    public query: z.ZodError | null,
+    public body: z.ZodError | null,
+  ) {
+    super('[ts-rest] request validation failed');
+  }
+}
+```
+
 ## Future Work
 
 As this pattern doesn't support a lambda per endpoint, it is planned to provide a helper utility to allow individual endpoints to be created.

--- a/libs/ts-rest/next/src/lib/ts-rest-next.spec.ts
+++ b/libs/ts-rest/next/src/lib/ts-rest-next.spec.ts
@@ -1,6 +1,10 @@
 import { initContract, ResponseValidationError } from '@ts-rest/core';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { createNextRoute, createNextRouter } from './ts-rest-next';
+import {
+  createNextRoute,
+  createNextRouter,
+  RequestValidationError,
+} from './ts-rest-next';
 import { z } from 'zod';
 
 const c = initContract();
@@ -283,6 +287,47 @@ describe('createNextRouter', () => {
       await resultingRouter(req, mockRes);
 
       expect(errorHandler).toHaveBeenCalled();
+    });
+  });
+
+  describe('request validation', () => {
+    it('fails with invalid query type', async () => {
+      const errorHandler = jest.fn();
+      const resultingRouter = createNextRouter(contract, nextEndpoint, {
+        throwRequestValidation: true,
+        errorHandler,
+      });
+
+      const req = mockReq('/test/100/throw', {
+        method: 'GET',
+        query: { field: 42 },
+      });
+
+      await resultingRouter(req, mockRes);
+
+      expect(errorHandler).toHaveBeenCalledWith(
+        expect.any(RequestValidationError),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('does not throw with invalid query type', async () => {
+      const errorHandler = jest.fn();
+      const resultingRouter = createNextRouter(contract, nextEndpoint, {
+        throwRequestValidation: false,
+        errorHandler,
+      });
+
+      const req = mockReq('/test/100/throw', {
+        method: 'GET',
+        query: { field: 42 },
+      });
+
+      await resultingRouter(req, mockRes);
+
+      expect(errorHandler).not.toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(400);
     });
   });
 


### PR DESCRIPTION
Adds the ability to throw a `RequestValidationError` for  `@ts-rest/next` (described in #443)

I wanted to customize the response when Zod request validation fails. This allows you to enable throwing a `RequestValidationError` which can then be handled by `errorHandler`. Uses the same `RequestValidationError` that exists within @ts-rest/(express, fastify, nest)