### PR TITLE
feat(ts-rest/nest): http exception options in TsRestException

### DIFF
--- a/.changeset/metal-mugs-smoke.md
+++ b/.changeset/metal-mugs-smoke.md
@@ -2,4 +2,4 @@
 '@ts-rest/nest': minor
 ---
 
-Adds support to provide a `cause` to `TsRestException`
+feat: `@ts-rest/nest` Adds support to provide a `cause` to `TsRestException`

--- a/.changeset/metal-mugs-smoke.md
+++ b/.changeset/metal-mugs-smoke.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/nest': minor
+---
+
+Adds support to provide a `cause` to `TsRestException`

--- a/libs/ts-rest/nest/src/lib/ts-rest-nest-handler.spec.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest-nest-handler.spec.ts
@@ -1337,4 +1337,38 @@ describe('ts-rest-nest-handler', () => {
       }),
     });
   });
+
+  it('should support including a nested error as the cause', async () => {
+    const c = initContract();
+
+    const contract = c.router({
+      getPosts: {
+        path: '/posts',
+        method: 'GET',
+        query: z.object({
+          limit: z.string(),
+        }),
+        responses: {
+          200: z.array(
+            z.object({
+              id: z.number(),
+            })
+          ),
+        },
+      },
+    });
+
+    const cause = new Error('the root cause');
+
+    const error = new TsRestException(contract.getPosts, {
+      status: 400,
+      body: {
+        message: 'Something went wrong'
+      }
+    }, {
+      cause
+    })
+
+    expect(error.cause).toEqual(cause);
+  })
 });

--- a/libs/ts-rest/nest/src/lib/ts-rest-nest-handler.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest-nest-handler.ts
@@ -11,6 +11,7 @@ import {
   ExecutionContext,
   Get,
   HttpException,
+  HttpExceptionOptions,
   Injectable,
   InternalServerErrorException,
   NestInterceptor,
@@ -165,8 +166,8 @@ export const tsRestHandler = <T extends AppRouter | AppRoute>(
  * Error you can throw to return a response from a handler
  */
 export class TsRestException<T extends AppRoute> extends HttpException {
-  constructor(route: T, response: ServerInferResponses<T>) {
-    super(response.body as Record<string, any>, response.status);
+  constructor(route: T, response: ServerInferResponses<T>, options?: HttpExceptionOptions) {
+    super(response.body as Record<string, any>, response.status, options);
   }
 }
 


### PR DESCRIPTION
Adds support for an optional `HttpExceptionOptions` argument available on the base class `HttpException` from NestJS

Allows developers to include additional context i.e. a root cause error in `TsRestException`, which can be useful in exception filters to centrally catch and log exceptions