### PR TITLE
feat(ts-rest/nest): allow TsRestException to be handled in Nest exception filters

### DIFF
--- a/.changeset/funny-taxis-brush.md
+++ b/.changeset/funny-taxis-brush.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/nest': minor
+---
+
+Allow TsRestException to be handled by NestJS exception filters

--- a/.changeset/funny-taxis-brush.md
+++ b/.changeset/funny-taxis-brush.md
@@ -2,4 +2,4 @@
 '@ts-rest/nest': minor
 ---
 
-Allow TsRestException to be handled by NestJS exception filters
+feat: `@ts-rest/nest` allow TsRestException to be handled by NestJS exception filters

--- a/libs/ts-rest/nest/src/lib/ts-rest-nest-handler.spec.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest-nest-handler.spec.ts
@@ -21,7 +21,7 @@ import { TsRest } from './ts-rest.decorator';
 import path = require('path');
 import { FileInterceptor } from '@nestjs/platform-express';
 import { FastifyAdapter } from '@nestjs/platform-fastify';
-import {Response} from "express-serve-static-core";
+import { Response } from 'express';
 
 export type Equal<a, b> = (<T>() => T extends a ? 1 : 2) extends <
   T

--- a/libs/ts-rest/nest/src/lib/ts-rest-nest-handler.spec.ts
+++ b/libs/ts-rest/nest/src/lib/ts-rest-nest-handler.spec.ts
@@ -8,9 +8,12 @@ import {
 import { z } from 'zod';
 import {
   ArgumentsHost,
-  Body, Catch,
-  Controller, ExceptionFilter,
-  Get, HttpException,
+  Body,
+  Catch,
+  Controller,
+  ExceptionFilter,
+  Get,
+  HttpException,
   Post,
   UploadedFile,
   UseInterceptors,


### PR DESCRIPTION
* Currently when a `TsRestExceptionFilter` is thrown from a controller, these cannot be caught in a nestjs exception filter. They are instead mapped directly to a response by the `TsRestHandlerInterceptor`
* This change now catches `TsRestExceptionFilter` and re-throws as a nestjs `HttpException`, mapping the response status/body from the original error and nesting it as a cause

This should be a backwards compatible change
* The body/status from a `HttpException` are mapped to the response by default with NestJS, which is what the ts-rest interceptor was doing originally
* We still maintain existing behaviour around response validation

Related issue - https://github.com/ts-rest/ts-rest/issues/450