### PR TITLE
fix: Fix variable name mismatch in docs code snippet

### DIFF
--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -328,7 +328,7 @@ export const client = initQueryClient(contract, {
 });
 
 export const Index = () => {
-  const { data, isLoading, error } = api.getPost.useQuery({
+  const { data, isLoading, error } = client.getPost.useQuery({
     params: { id: '1' },
   });
 


### PR DESCRIPTION
Noticed a small variable name mismatch while reading the docs.