### PR TITLE
feat: add initial compatibility with react-query v5

### DIFF
--- a/.changeset/five-singers-jog.md
+++ b/.changeset/five-singers-jog.md
@@ -1,0 +1,7 @@
+---
+'@ts-rest/react-query': patch
+'@ts-rest/vue-query': patch
+---
+
+fix: use object-syntax in react-query to support [@tanstack/react-query@^5.0.0](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5)
+fix: add @tanstack/vue-query@^5.0.0 as peer dependency

--- a/.changeset/five-singers-jog.md
+++ b/.changeset/five-singers-jog.md
@@ -3,5 +3,5 @@
 '@ts-rest/vue-query': patch
 ---
 
-fix: use object-syntax in react-query to support [@tanstack/react-query@^5.0.0](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5)
-fix: add @tanstack/vue-query@^5.0.0 as peer dependency
+feat: use object-syntax in react-query to support [@tanstack/react-query@^5.0.0](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5)
+feat: add @tanstack/vue-query@^5.0.0 as peer dependency

--- a/.changeset/five-singers-jog.md
+++ b/.changeset/five-singers-jog.md
@@ -4,4 +4,6 @@
 ---
 
 feat: use object-syntax in react-query to support [@tanstack/react-query@^5.0.0](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5)
+- note: This does **not** implement a complete migration to v5 but lays the groundwork to get the ball rolling and apps running again.
+
 feat: add @tanstack/vue-query@^5.0.0 as peer dependency

--- a/.changeset/five-singers-jog.md
+++ b/.changeset/five-singers-jog.md
@@ -3,7 +3,7 @@
 '@ts-rest/vue-query': minor
 ---
 
-feat: use object-syntax in react-query to support [@tanstack/react-query@^5.0.0](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5)
+feat: `@ts-rest/react-query` use object-syntax in react-query to support [@tanstack/react-query@^5.0.0](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5)
 - note: This does **not** implement a complete migration to v5 but lays the groundwork to get the ball rolling and apps running again.
 
-feat: add @tanstack/vue-query@^5.0.0 as peer dependency
+feat: `@ts-rest/vue-query` add @tanstack/vue-query@^5.0.0 as peer dependency

--- a/.changeset/five-singers-jog.md
+++ b/.changeset/five-singers-jog.md
@@ -1,6 +1,6 @@
 ---
-'@ts-rest/react-query': patch
-'@ts-rest/vue-query': patch
+'@ts-rest/react-query': minor
+'@ts-rest/vue-query': minor
 ---
 
 feat: use object-syntax in react-query to support [@tanstack/react-query@^5.0.0](https://tanstack.com/query/latest/docs/react/guides/migrating-to-v5)

--- a/libs/ts-rest/react-query/package.json
+++ b/libs/ts-rest/react-query/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "@tanstack/react-query": "^4.0.0",
+    "@tanstack/react-query": "^4.0.0 || ^5.0.0",
     "zod": "^3.22.3"
   },
   "peerDependenciesMeta": {

--- a/libs/ts-rest/react-query/src/lib/react-query.ts
+++ b/libs/ts-rest/react-query/src/lib/react-query.ts
@@ -37,7 +37,7 @@ import {
 const queryFn = <TAppRoute extends AppRoute, TClientArgs extends ClientArgs>(
   route: TAppRoute,
   clientArgs: TClientArgs,
-  args?: ClientInferRequest<AppRouteMutation, ClientArgs>
+  args?: ClientInferRequest<AppRouteMutation, ClientArgs>,
 ): QueryFunction<TAppRoute['responses']> => {
   return async (queryFnContext?: QueryFunctionContext) => {
     const { query, params, body, headers, extraHeaders, ...extraInputArgs } =
@@ -48,7 +48,7 @@ const queryFn = <TAppRoute extends AppRoute, TClientArgs extends ClientArgs>(
       clientArgs.baseUrl,
       params,
       route,
-      !!clientArgs.jsonQuery
+      !!clientArgs.jsonQuery,
     );
 
     const result = await fetchApi({
@@ -76,28 +76,28 @@ const queryFn = <TAppRoute extends AppRoute, TClientArgs extends ClientArgs>(
 
 const getRouteUseQuery = <
   TAppRoute extends AppRoute,
-  TClientArgs extends ClientArgs
+  TClientArgs extends ClientArgs,
 >(
   route: TAppRoute,
-  clientArgs: TClientArgs
+  clientArgs: TClientArgs,
 ) => {
   return (
     queryKey: QueryKey,
     args?: ClientInferRequest<AppRouteMutation, ClientArgs>,
-    options?: TanStackUseQueryOptions<TAppRoute['responses']>
+    options?: TanStackUseQueryOptions<TAppRoute['responses']>,
   ) => {
     const dataFn = queryFn(route, clientArgs, args);
 
-    return useQuery(queryKey, dataFn, options);
+    return useQuery({ queryKey, queryFn: dataFn, ...options });
   };
 };
 
 const getRouteUseQueries = <
   TAppRoute extends AppRoute,
-  TClientArgs extends ClientArgs
+  TClientArgs extends ClientArgs,
 >(
   route: TAppRoute,
-  clientArgs: TClientArgs
+  clientArgs: TClientArgs,
 ) => {
   return (args: Parameters<DataReturnQueries<TAppRoute, TClientArgs>>[0]) => {
     const queries = args.queries.map((fullQueryArgs: any) => {
@@ -116,17 +116,17 @@ const getRouteUseQueries = <
 
 const getRouteUseInfiniteQuery = <
   TAppRoute extends AppRoute,
-  TClientArgs extends ClientArgs
+  TClientArgs extends ClientArgs,
 >(
   route: TAppRoute,
-  clientArgs: TClientArgs
+  clientArgs: TClientArgs,
 ) => {
   return (
     queryKey: QueryKey,
     argsMapper: (
-      context: QueryFunctionContext
+      context: QueryFunctionContext,
     ) => ClientInferRequest<AppRouteMutation, ClientArgs>,
-    options?: TanStackUseInfiniteQueryOptions<TAppRoute['responses']>
+    options?: TanStackUseInfiniteQueryOptions<TAppRoute['responses']>,
   ) => {
     const dataFn: QueryFunction<TAppRoute['responses']> = async (context) => {
       const resultingQueryArgs = argsMapper(context);
@@ -136,36 +136,38 @@ const getRouteUseInfiniteQuery = <
       return innerDataFn(undefined as any);
     };
 
-    return useInfiniteQuery(queryKey, dataFn, options);
+    return useInfiniteQuery({ queryKey, queryFn: dataFn, ...options });
   };
 };
 
 const getRouteUseMutation = <
   TAppRoute extends AppRoute,
-  TClientArgs extends ClientArgs
+  TClientArgs extends ClientArgs,
 >(
   route: TAppRoute,
-  clientArgs: TClientArgs
+  clientArgs: TClientArgs,
 ) => {
   return (options?: TanStackUseMutationOptions<TAppRoute['responses']>) => {
     const mutationFunction = async (
-      args?: ClientInferRequest<AppRouteMutation, ClientArgs>
+      args?: ClientInferRequest<AppRouteMutation, ClientArgs>,
     ) => {
       const dataFn = queryFn(route, clientArgs, args);
 
       return dataFn(undefined as any);
     };
 
-    return useMutation(
-      mutationFunction as () => Promise<ZodInferOrType<TAppRoute['responses']>>,
-      options
-    );
+    return useMutation({
+      mutationFn: mutationFunction as () => Promise<
+        ZodInferOrType<TAppRoute['responses']>
+      >,
+      ...options,
+    });
   };
 };
 
 export type InitClientReturn<
   T extends AppRouter,
-  TClientArgs extends ClientArgs
+  TClientArgs extends ClientArgs,
 > = {
   [TKey in keyof T]: T[TKey] extends AppRoute
     ? Without<AppRouteFunctions<T[TKey], TClientArgs>, never>
@@ -178,13 +180,13 @@ const ClientParameters = Symbol('ClientParameters');
 
 export const initQueryClient = <
   T extends AppRouter,
-  TClientArgs extends ClientArgs
+  TClientArgs extends ClientArgs,
 >(
   router: T,
-  clientArgs: TClientArgs
+  clientArgs: TClientArgs,
 ): InitClientReturn<T, TClientArgs> => {
   const recursiveInit = <TInner extends AppRouter>(
-    innerRouter: TInner
+    innerRouter: TInner,
   ): InitClientReturn<TInner, TClientArgs> => {
     return Object.fromEntries(
       Object.entries(innerRouter).map(([key, subRouter]) => {
@@ -202,73 +204,81 @@ export const initQueryClient = <
                 queryClient: QueryClient,
                 queryKey: QueryKey,
                 args: ClientInferRequest<AppRouteMutation, ClientArgs>,
-                options?: FetchQueryOptions<any>
+                options?: FetchQueryOptions<any>,
               ) => {
                 const dataFn = queryFn(subRouter, clientArgs, args);
-                return queryClient.fetchQuery(queryKey, dataFn, options);
+                return queryClient.fetchQuery({
+                  queryKey,
+                  queryFn: dataFn,
+                  ...options,
+                });
               },
               fetchInfiniteQuery: (
                 queryClient: QueryClient,
                 queryKey: QueryKey,
                 argsMapper: (
-                  context: QueryFunctionContext
+                  context: QueryFunctionContext,
                 ) => ClientInferRequest<AppRouteMutation, ClientArgs>,
-                options?: FetchQueryOptions<any>
+                options?: FetchQueryOptions<any>,
               ) => {
-                return queryClient.fetchInfiniteQuery(
+                return queryClient.fetchInfiniteQuery({
                   queryKey,
-                  async (context) => {
+                  queryFn: async (context) => {
                     const resultingQueryArgs = argsMapper(context);
 
                     const innerDataFn = queryFn(
                       subRouter,
                       clientArgs,
-                      resultingQueryArgs
+                      resultingQueryArgs,
                     );
 
                     return innerDataFn(undefined as any);
                   },
-                  options
-                );
+                  ...options,
+                });
               },
               prefetchQuery: (
                 queryClient: QueryClient,
                 queryKey: QueryKey,
                 args: ClientInferRequest<AppRouteMutation, ClientArgs>,
-                options?: FetchQueryOptions<any>
+                options?: FetchQueryOptions<any>,
               ) => {
                 const dataFn = queryFn(subRouter, clientArgs, args);
 
-                return queryClient.prefetchQuery(queryKey, dataFn, options);
+                return queryClient.prefetchQuery({
+                  queryKey,
+                  queryFn: dataFn,
+                  ...options,
+                });
               },
               prefetchInfiniteQuery: (
                 queryClient: QueryClient,
                 queryKey: QueryKey,
                 argsMapper: (
-                  context: QueryFunctionContext
+                  context: QueryFunctionContext,
                 ) => ClientInferRequest<AppRouteMutation, ClientArgs>,
-                options?: FetchQueryOptions<any>
+                options?: FetchQueryOptions<any>,
               ) => {
-                return queryClient.prefetchInfiniteQuery(
+                return queryClient.prefetchInfiniteQuery({
                   queryKey,
-                  async (context) => {
+                  queryFn: async (context) => {
                     const resultingQueryArgs = argsMapper(context);
 
                     const innerDataFn = queryFn(
                       subRouter,
                       clientArgs,
-                      resultingQueryArgs
+                      resultingQueryArgs,
                     );
 
                     return innerDataFn(undefined as any);
                   },
-                  options
-                );
+                  ...options,
+                });
               },
               getQueryData: (
                 queryClient: QueryClient,
                 queryKey: QueryKey,
-                filters?: QueryFilters
+                filters?: QueryFilters,
               ) => {
                 return queryClient.getQueryData(queryKey, filters);
               },
@@ -276,22 +286,26 @@ export const initQueryClient = <
                 queryClient: QueryClient,
                 queryKey: QueryKey,
                 args: ClientInferRequest<AppRouteMutation, ClientArgs>,
-                options?: FetchQueryOptions<any>
+                options?: FetchQueryOptions<any>,
               ) => {
                 const dataFn = queryFn(subRouter, clientArgs, args);
 
-                return queryClient.ensureQueryData(queryKey, dataFn, options);
+                return queryClient.ensureQueryData({
+                  queryKey,
+                  queryFn: dataFn,
+                  ...options,
+                });
               },
               getQueriesData: (
                 queryClient: QueryClient,
-                filters: QueryFilters
+                filters: QueryFilters,
               ) => {
                 return queryClient.getQueriesData(filters);
               },
               setQueryData: (
                 queryClient: QueryClient,
                 queryKey: QueryKey,
-                updater: any
+                updater: any,
               ) => {
                 return queryClient.setQueryData(queryKey, updater);
               },
@@ -300,7 +314,7 @@ export const initQueryClient = <
         } else {
           return [key, recursiveInit(subRouter)];
         }
-      })
+      }),
     );
   };
 
@@ -315,7 +329,7 @@ export const initQueryClient = <
 
 type InitUseTsRestQueryClientReturn<
   T extends AppRouter,
-  TClientArgs extends ClientArgs
+  TClientArgs extends ClientArgs,
 > = {
   [TKey in keyof T]: T[TKey] extends AppRoute
     ? Without<AppRouteFunctionsWithQueryClient<T[TKey], TClientArgs>, never>
@@ -326,9 +340,9 @@ type InitUseTsRestQueryClientReturn<
 
 export const useTsRestQueryClient = <
   T extends AppRouter,
-  TClientArgs extends ClientArgs
+  TClientArgs extends ClientArgs,
 >(
-  client: InitClientReturn<T, TClientArgs>
+  client: InitClientReturn<T, TClientArgs>,
 ): InitUseTsRestQueryClientReturn<T, TClientArgs> => {
   // @ts-expect-error - hidden symbol, so we can refetch the original client router and clientArgs
   const { router } = client[ClientParameters] as unknown as {
@@ -340,7 +354,7 @@ export const useTsRestQueryClient = <
 
   const recursiveInit = <TInner extends AppRouter>(
     innerRouter: TInner,
-    innerClient: InitClientReturn<TInner, TClientArgs>
+    innerClient: InitClientReturn<TInner, TClientArgs>,
   ): InitUseTsRestQueryClientReturn<TInner, TClientArgs> => {
     return Object.fromEntries(
       Object.entries(innerRouter).map(([key, subRouter]) => {
@@ -358,63 +372,63 @@ export const useTsRestQueryClient = <
               fetchQuery: (
                 queryKey: QueryKey,
                 args: ClientInferRequest<AppRouteMutation, ClientArgs>,
-                options?: FetchQueryOptions<any>
+                options?: FetchQueryOptions<any>,
               ) =>
                 routeFunctions.fetchQuery(
                   queryClient,
                   queryKey,
                   args as any,
-                  options
+                  options,
                 ),
               fetchInfiniteQuery: (
                 queryKey: QueryKey,
                 argsMapper: (
-                  context: QueryFunctionContext
+                  context: QueryFunctionContext,
                 ) => ClientInferRequest<AppRouteMutation, ClientArgs>,
-                options?: FetchQueryOptions<any>
+                options?: FetchQueryOptions<any>,
               ) =>
                 routeFunctions.fetchInfiniteQuery(
                   queryClient,
                   queryKey,
                   argsMapper as any,
-                  options
+                  options,
                 ),
               prefetchQuery: (
                 queryKey: QueryKey,
                 args: ClientInferRequest<AppRouteMutation, ClientArgs>,
-                options?: FetchQueryOptions<any>
+                options?: FetchQueryOptions<any>,
               ) =>
                 routeFunctions.prefetchQuery(
                   queryClient,
                   queryKey,
                   args as any,
-                  options
+                  options,
                 ),
               prefetchInfiniteQuery: (
                 queryKey: QueryKey,
                 argsMapper: (
-                  context: QueryFunctionContext
+                  context: QueryFunctionContext,
                 ) => ClientInferRequest<AppRouteMutation, ClientArgs>,
-                options?: FetchQueryOptions<any>
+                options?: FetchQueryOptions<any>,
               ) =>
                 routeFunctions.prefetchInfiniteQuery(
                   queryClient,
                   queryKey,
                   argsMapper as any,
-                  options
+                  options,
                 ),
               getQueryData: (queryKey: QueryKey, filters?: QueryFilters) =>
                 routeFunctions.getQueryData(queryClient, queryKey, filters),
               ensureQueryData: (
                 queryKey: QueryKey,
                 args: ClientInferRequest<AppRouteMutation, ClientArgs>,
-                options?: FetchQueryOptions<any>
+                options?: FetchQueryOptions<any>,
               ) =>
                 routeFunctions.ensureQueryData(
                   queryClient,
                   queryKey,
                   args as any,
-                  options
+                  options,
                 ),
               getQueriesData: (filters: QueryFilters) =>
                 routeFunctions.getQueriesData(queryClient, filters),
@@ -425,7 +439,7 @@ export const useTsRestQueryClient = <
         } else {
           return [key, recursiveInit(subRouter, innerClient[key] as any)];
         }
-      })
+      }),
     );
   };
 

--- a/libs/ts-rest/vue-query/package.json
+++ b/libs/ts-rest/vue-query/package.json
@@ -21,7 +21,7 @@
     "directory": "libs/ts-rest/vue-query"
   },
   "peerDependencies": {
-    "@tanstack/vue-query": "^4.0.0",
+    "@tanstack/vue-query": "^4.0.0 || ^5.0.0",
     "zod": "^3.22.3"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,7 +552,7 @@ importers:
   libs/ts-rest/react-query:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^4.0.0
+        specifier: ^4.0.0 || ^5.0.0
         version: 4.33.0(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -573,7 +573,7 @@ importers:
   libs/ts-rest/vue-query:
     dependencies:
       '@tanstack/vue-query':
-        specifier: ^4.0.0
+        specifier: ^4.0.0 || ^5.0.0
         version: 4.33.0(vue@3.3.4)
       zod:
         specifier: ^3.22.3


### PR DESCRIPTION
relates to #415 

This PR establishes compatibility with TanStack Query v5 by using object-syntax internally. 
The external API of @ts-rest/react-query remains unchanged.
Compatibility with v4 remains unchanged.

It prevents React from throwing a runtime error on app launch.
It does **not** implement a full migration to v5 but lays the groundwork to get the ball rolling and apps running again.

Since this is not a fully featured migration I marked it as a patch.