### PR TITLE
feat(core): Support application/x-www-form-urlencoded content type

### DIFF
--- a/.changeset/thin-numbers-taste.md
+++ b/.changeset/thin-numbers-taste.md
@@ -2,4 +2,4 @@
 '@ts-rest/core': minor
 ---
 
-Add support for x-www-form-urlencoded content-type
+feat: `@ts-rest/core`: Add support for `x-www-form-urlencoded` content-type to core client

--- a/.changeset/thin-numbers-taste.md
+++ b/.changeset/thin-numbers-taste.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': minor
+---
+
+Add support for x-www-form-urlencoded content-type

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -61,6 +61,15 @@ const postsRouter = c.router({
       authorId: z.string(),
     }),
   },
+  createPostXForm: {
+    method: 'POST',
+    path: '/posts',
+    responses: {
+      200: c.response<Post>(),
+    },
+    body: z.string(),
+    contentType: 'application/x-www-form-urlencoded'
+  },
   mutationWithQuery: {
     method: 'POST',
     path: '/posts',
@@ -325,7 +334,7 @@ describe('client', () => {
           published: true,
           filter: { title: 'test' },
         },
-        
+
       });
 
       expect(result.body).toStrictEqual(value);
@@ -434,6 +443,32 @@ describe('client', () => {
       expect(result.status).toBe(200);
       expect(result.headers.get('Content-Length')).toBe('15');
       expect(result.headers.get('Content-Type')).toBe('application/json');
+    });
+
+    it('w/ body and content-type header', async () => {
+      const value = "key=value";
+      fetchMock.postOnce(
+        {
+          url: 'https://api.com/posts',
+          headers: {
+            "content-type": "application/x-www-form-urlencoded"
+          }
+        },
+        {
+          body: value,
+          status: 200,
+          headers: {
+            "content-type": "application/x-www-form-urlencoded"
+          }
+        }
+      );
+
+      const result = await client.posts.createPostXForm({
+        body: "key=value",
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.headers.get('Content-Type')).toBe('application/x-www-form-urlencoded');
     });
 
     it('w/ query params', async () => {

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -221,6 +221,27 @@ export const fetchApi = ({
     });
   }
 
+  if (route.method !== 'GET' && route.contentType === 'application/x-www-form-urlencoded') {
+    const headers = {
+      ...combinedHeaders,
+      'content-type': 'application/x-www-form-urlencoded',
+    }
+    return apiFetcher({
+      route,
+      path,
+      method: route.method,
+      credentials: clientArgs.credentials,
+      headers,
+      body: body instanceof FormData ? body : createFormData(body),
+      rawBody: body,
+      rawQuery: query,
+      contentType: 'application/x-www-form-urlencoded',
+      signal,
+      next,
+      ...extraInputArgs,
+    });
+  }
+
   const includeContentTypeHeader =
     route.method !== 'GET' && body !== null && body !== undefined;
 

--- a/libs/ts-rest/core/src/lib/dsl.ts
+++ b/libs/ts-rest/core/src/lib/dsl.ts
@@ -54,7 +54,7 @@ export type AppRouteQuery = AppRouteCommon & {
  */
 export type AppRouteMutation = AppRouteCommon & {
   method: 'POST' | 'DELETE' | 'PUT' | 'PATCH';
-  contentType?: 'application/json' | 'multipart/form-data';
+  contentType?: 'application/json' | 'multipart/form-data' | 'application/x-www-form-urlencoded';
   body: ContractAnyType;
 };
 


### PR DESCRIPTION
This pull request aims to support `application/x-www-form-urlencoded` `content-type`. Currently it's unsupported and attempting to use the correct headers causes issues. Closes #453 