### PR TITLE
feat: allow nextjs14 as a peer dependency

### DIFF
--- a/.changeset/orange-llamas-battle.md
+++ b/.changeset/orange-llamas-battle.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/next': minor
+---
+
+feat: `@ts-rest/next` allow nextjs as a peer dependency

--- a/libs/ts-rest/next/package.json
+++ b/libs/ts-rest/next/package.json
@@ -2,7 +2,7 @@
   "name": "@ts-rest/next",
   "version": "3.30.5",
   "peerDependencies": {
-    "next": "^12.0.0 || ^13.0.0",
+    "next": "^12.0.0 || ^13.0.0 || ^14.0.0",
     "zod": "^3.22.3"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,7 +531,7 @@ importers:
   libs/ts-rest/next:
     dependencies:
       next:
-        specifier: ^12.0.0 || ^13.0.0
+        specifier: ^12.0.0 || ^13.0.0 || ^14.0.0
         version: 13.3.0(@babel/core@7.19.1)(react-dom@18.2.0)(react@18.2.0)(sass@1.55.0)
       zod:
         specifier: ^3.22.3


### PR DESCRIPTION
aims to partially close #428 

- note: this is not to implement things like server actions/next13 route handlers/server components. This is just to get our foot through the door. 
