### PR TITLE
react-query docs for QueryClientProvider

### DIFF
--- a/apps/docs/docs/react-query.mdx
+++ b/apps/docs/docs/react-query.mdx
@@ -8,6 +8,22 @@ import { InstallTabs } from '@site/src/components/InstallTabs';
 
 This is a client using `@ts-rest/react-query`, using `@tanstack/react-query` under the hood.
 
+### Initializing QueryClientProvider
+
+After installation, ensure that your React application is wrapped with `react-query`'s `QueryClientProvider`. This provider is essential for managing the state and lifecycle of your queries and mutations.
+
+```tsx
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
+
+function App() {
+  return <QueryClientProvider client={queryClient}>...</QueryClientProvider>;
+}
+```
+
+For more detailed information, refer to the [official `react-query` documentation](https://tanstack.com/query/v4/docs/react/reference/QueryClientProvider).
+
 ## initQueryClient
 
 The below snippet is how you'd create a query client, this is pretty much the same structure as the `@ts-rest/core` client.
@@ -48,7 +64,7 @@ Once you've created a client using `initQueryClient`, you may traverse the objec
 const queryResult = client.posts.get.useQuery(
   ['posts'], // <- queryKey
   { params: { id: '1' } }, // <- Query params, Params, Body etc (all typed)
-  { staleTime: 1000 } // <- react-query options (optional)
+  { staleTime: 1000 }, // <- react-query options (optional)
 );
 ```
 
@@ -121,7 +137,7 @@ const { isLoading, data, hasNextPage, fetchNextPage } = useInfiniteQuery(
   {
     getNextPageParam: (lastPage, allPages) => lastPage.nextCursor,
     getPreviousPageParam: (firstPage, allPages) => firstPage.prevCursor,
-  }
+  },
 );
 ```
 
@@ -146,7 +162,7 @@ export function Index() {
               ? { take: PAGE_SIZE, skip: allPages.length * PAGE_SIZE }
               : undefined
             : undefined,
-      }
+      },
     );
 
   if (isLoading) {
@@ -158,7 +174,7 @@ export function Index() {
   }
 
   const posts = data.pages.flatMap((page) =>
-    page.status === 200 ? page.body.posts : []
+    page.status === 200 ? page.body.posts : [],
   );
 
   //...
@@ -214,23 +230,28 @@ const App = () => {
   const apiQueryClient = useTsRestQueryClient(client);
 
   // You can either use apiQueryClient or client to call useQuery, useMutation, etc.
-  const { data, isLoading, error } = apiQueryClient.posts.get.useQuery(['posts']);
+  const { data, isLoading, error } = apiQueryClient.posts.get.useQuery([
+    'posts',
+  ]);
   const { mutate, isLoading } = client.posts.create.useMutation();
 
   const createPost = async () => {
-    return mutate({ body: { title: 'Hello World' } }, {
-      onSuccess: async (data) => {
-        //  this is typed ^
-        apiQueryClient.posts.get.setQueryData(['posts'], (oldPosts) => {
-          //                               this is also typed ^
-          return {
-            ...oldPosts,
-            body: [...oldPosts.body, data.body],
-          }
-        });
-      }
-    });
-  }
+    return mutate(
+      { body: { title: 'Hello World' } },
+      {
+        onSuccess: async (data) => {
+          //  this is typed ^
+          apiQueryClient.posts.get.setQueryData(['posts'], (oldPosts) => {
+            //                               this is also typed ^
+            return {
+              ...oldPosts,
+              body: [...oldPosts.body, data.body],
+            };
+          });
+        },
+      },
+    );
+  };
 
   if (isLoading) {
     return <div>Loading...</div>;


### PR DESCRIPTION
Adds information about initializing the `QueryClientProvider` for `react-query` (described in #452).