### PR TITLE
Correctly add `style: deepObject` for optional objects

### DIFF
--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
@@ -619,6 +619,75 @@ describe('ts-rest-open-api', () => {
       });
     });
 
+    it('works with zod optional query parameters', () => {
+      const routerWithRefine = c.router({
+        endpointWithZodRefine: {
+          method: 'GET',
+          path: '/optional',
+          responses: {
+            200: c.type<null>(),
+          },
+          query: z.object({
+            foo: z
+              .object({
+                baz: z.string().describe('Baz').optional(),
+                bar: z.string().describe('Bar').optional(),
+              })
+              .describe('Foo')
+              .optional(),
+          }),
+        },
+      });
+
+      const schema = generateOpenApi(routerWithRefine, {
+        info: { title: 'Blog API', version: '0.1' },
+      });
+
+      expect(schema).toEqual({
+        info: {
+          title: 'Blog API',
+          version: '0.1',
+        },
+        openapi: '3.0.2',
+        paths: {
+          '/optional': {
+            get: {
+              deprecated: undefined,
+              description: undefined,
+              parameters: [
+                {
+                  description: 'Foo',
+                  in: 'query',
+                  name: 'foo',
+                  schema: {
+                    properties: {
+                      bar: {
+                        description: 'Bar',
+                        type: 'string',
+                      },
+                      baz: {
+                        description: 'Baz',
+                        type: 'string',
+                      },
+                    },
+                    type: 'object',
+                  },
+                  style: 'deepObject',
+                },
+              ],
+              responses: {
+                '200': {
+                  description: '200',
+                },
+              },
+              summary: undefined,
+              tags: [],
+            },
+          },
+        },
+      });
+    });
+
     it('works with zod transform', () => {
       const routerWithTransform = c.router({
         endpointWithZodTransform: {

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
@@ -130,7 +130,13 @@ const getQueryParametersFromZod = (zodObject: unknown, jsonQuery = false) => {
 
   return Object.entries(zodShape).map(([key, value]) => {
     const { description, ...schema } = getOpenApiSchemaFromZod(value)!;
-    const isObject = (value as z.ZodTypeAny)._def.typeName === 'ZodObject';
+    const isObject = (obj: z.ZodTypeAny) => {
+      while (obj._def.innerType) {
+        obj = obj._def.innerType;
+      }
+
+      return obj._def.typeName === 'ZodObject';
+    };
     const isRequired = !(value as z.ZodTypeAny).isOptional();
 
     return {
@@ -147,7 +153,9 @@ const getQueryParametersFromZod = (zodObject: unknown, jsonQuery = false) => {
             },
           }
         : {
-            ...(isObject && { style: 'deepObject' as const }),
+            ...(isObject(value as z.ZodTypeAny) && {
+              style: 'deepObject' as const,
+            }),
             schema: schema,
           }),
     };


### PR DESCRIPTION
Fixes #477 