### PR TITLE
Small corrections to documentation

### DIFF
--- a/apps/docs/docs/fastify/fastify.mdx
+++ b/apps/docs/docs/fastify/fastify.mdx
@@ -9,10 +9,10 @@ import { InstallTabs } from '@site/src/components/InstallTabs';
 ## Usage
 
 ```typescript
-import * as fastify from 'fastify';
+import Fastify from 'fastify';
 import { initServer } from '@ts-rest/fastify';
 
-const app = fastify();
+const app = Fastify();
 
 const s = initServer();
 

--- a/apps/docs/docs/next.mdx
+++ b/apps/docs/docs/next.mdx
@@ -37,7 +37,7 @@ const router = createNextRoute(api, {
 export default createNextRouter(api, router);
 ```
 
-`createNextRouter` is a function that takes a router and a complete router, and creates endpoints, with the correct methods, paths and callbacks.
+`createNextRouter` is a function that takes a contract and a complete router, and creates endpoints, with the correct methods, paths and callbacks.
 
 ### JSON Query Parameters
 


### PR DESCRIPTION
Fix a couple of small mistakes I found with the documentation.

The error you get with the Fastify example right now:
![Screenshot 2024-02-04 at 1 49 29 pm](https://github.com/ts-rest/ts-rest/assets/21004798/a232394b-6402-46ec-bfcd-127670c60d87)

I have updated the example to import Fastify the way they import it in "Quick Start" example on https://fastify.dev.

Looks like a great project! Can't wait to try it out more!