### PR TITLE
feat(express): Export type `TsRestExpressOptions`

### DIFF
--- a/libs/ts-rest/express/src/index.ts
+++ b/libs/ts-rest/express/src/index.ts
@@ -4,5 +4,6 @@ export type {
   AppRouteOptions,
   TsRestRequest,
   TsRestRequestHandler,
+  TsRestExpressOptions,
 } from './lib/types';
 export { RequestValidationError } from './lib/request-validation-error';


### PR DESCRIPTION
This PR introduces flexibility for `globalMiddleware` handlers defined in other files.

```ts
createExpressEndpoints(contract, tsRrouter, app, {
  globalMiddleware: [
    (req, res, next) => {
      // define global middleware logic here...
    } 
  ],
});
```
This gets pretty messy especially when business logic gets huge in some middlewares.
Fixes problems mentioned in #497 

Take care :+1: 