### PR TITLE
feat: create helper functions for route and implementation separation

### DIFF
--- a/.changeset/bright-bobcats-happen.md
+++ b/.changeset/bright-bobcats-happen.md
@@ -1,0 +1,6 @@
+---
+'@ts-rest/express': patch
+'@ts-rest/core': patch
+---
+
+Provide helper functions for creating separate route definitions and implementations

--- a/apps/docs/docs/core/helpers.md
+++ b/apps/docs/docs/core/helpers.md
@@ -1,0 +1,95 @@
+# Contract Helpers
+
+For most cases, the simplest way to defining a contract would be just to follow the proposed structure in [Contract](./core.md). However, there are some cases where you may want to define a contract in separate files or use a different structure. Or, you may want to reuse route or response definitions across multiple contracts. 
+
+In this case, you can use the following helpers to define your contract.
+
+## `makeRoute`
+
+`makeRoute` is a helper function that creates a single route definition. This route definition can be exported and reused across multiple contracts.
+
+Example usage where routes are being defined independently of the contract definition and then combined:
+
+```ts title="src/contracts/posts.ts"
+import { makeRoute, makeType } from '@ts-rest/core';
+import z from 'zod'
+
+const createPost = makeRoute({
+  method: 'POST',
+  path: '/posts',
+  responses: {
+    201: makeType<Post>(),
+  },
+  body: z.object({
+    title: z.string(),
+    content: z.string(),
+    published: z.boolean().optional(),
+    description: z.string().optional(),
+  }),
+  summary: 'Create a post',
+  metadata: { role: 'user' } as const,
+});
+
+const getPosts = makeRoute({
+  method: 'GET',
+  path: '/posts',
+  responses: {
+    200: makeType<{ posts: Post[]; total: number }>(),
+  },
+  headers: z.object({
+    pagination: z.string().optional(),
+  }),
+  query: z.object({
+    take: z.string().transform(Number).optional(),
+    skip: z.string().transform(Number).optional(),
+    search: z.string().optional(),
+  }),
+  summary: 'Get all posts',
+  metadata: { role: 'guest' } as const,
+});
+
+const c = initContract();
+
+export const contract = c.router({ createPost, getPosts });
+```
+
+## `makeResponses`
+
+`makeResponses` is a helper function that creates a responses object. This responses object can be exported and reused across multiple contracts. 
+
+Example usage where there are defined default error responses and reused across multiple routes:
+
+```ts title="src/contracts/defaultErrorResponses.ts"
+import { makeResponses, makeType } from '@ts-rest/core';
+
+export const defaultErrorResponses = makeResponses({
+  400: makeType<{ message: string }>(),
+  500: makeType<{ message: string }>(),
+});
+
+// src/contracts/posts.ts
+import { defaultErrorResponses } from './defaultErrorResponses';
+
+const c = initContract();
+export const contract = c.router({
+  createPost: {
+    method: 'POST',
+    path: '/posts',
+    responses: {
+      201: makeType<Post>,
+      ...defaultErrorResponses,
+    },
+    //...
+  },
+  getPosts: {
+    method: 'GET',
+    path: '/posts',
+    responses: {
+      200: makeType<{ posts: Post[]; total: number }>,
+      ...defaultErrorResponses,
+    },
+    //...
+  },
+});
+
+```

--- a/apps/docs/docs/express/helpers.md
+++ b/apps/docs/docs/express/helpers.md
@@ -1,0 +1,38 @@
+# Route Helpers
+
+Easiest way to get started with using `ts-core/express` is just by following the [Express Server](express.mdx), but there might be cases where you want to split the implementation of your routes into separate files or use a different structure. 
+
+In this case, you can use the following helpers to define implementation for your routes.
+
+## `makeAppRouteImplementation`
+
+`makeAppRouteImplementation` is a helper function that enables you in a type-safe way to define the implementation of a single route. This route implementation can be exported and reused across multiple routes if it is desired.
+
+Example usage where the route implementation is being defined independently of the route server definition. Building on the contract example from [Contract](../core/core.md):
+
+```ts title="src/routes/posts.ts"
+import { makeAppRouteImplementation } from '@ts-core/express';
+import { contract } from '../contracts'
+
+export const createPostImpl = makeAppRouteImplementation(contract.createPost, async (req, res) => {
+  // create post implementation
+  return { status: 201, body: /** created post */ };
+});
+
+export const getPostsImpl = makeAppRouteImplementation(contract.getPosts, async (req, res) => {
+  // get posts implementation
+  return { status: 200, body: /** posts */ };
+});
+```
+
+```ts title="src/server.ts"
+import { initServer } from '@ts-core/express';
+import { createPostImpl, getPostsImpl } from './routes/posts';
+import { contract } from './contracts';
+
+const s = initServer();
+
+const router = s.router(contract, { createPost: createPostImpl, getPosts: getPostsImpl });
+```
+
+

--- a/apps/docs/sidebars.js
+++ b/apps/docs/sidebars.js
@@ -69,6 +69,7 @@ const sidebars = {
       collapsed: false,
       items: [
         { type: 'doc', id: 'core/core' },
+        { type: 'doc', id: 'core/helpers' },
         { type: 'doc', id: 'core/fetch' },
         { type: 'doc', id: 'core/custom' },
         { type: 'doc', id: 'core/infer-types' },
@@ -117,6 +118,7 @@ const sidebars = {
       items: [
         { type: 'doc', id: 'express/express' },
         { type: 'doc', id: 'express/middleware' },
+        { type: 'doc', id: 'express/helpers' },
       ],
     },
     {

--- a/libs/ts-rest/core/src/index.ts
+++ b/libs/ts-rest/core/src/index.ts
@@ -9,3 +9,4 @@ export * from './lib/server';
 export * from './lib/response-validation-error';
 export * from './lib/unknown-status-error';
 export * from './lib/infer-types';
+export * from './lib/helpers';

--- a/libs/ts-rest/core/src/lib/helpers.ts
+++ b/libs/ts-rest/core/src/lib/helpers.ts
@@ -1,0 +1,36 @@
+import {
+  type AppRoute,
+  type ContractAnyType,
+  type ContractNullType,
+  type ContractOtherResponse,
+  type ContractPlainType,
+  ContractPlainTypeRuntimeSymbol,
+} from './dsl';
+
+/**
+ * Create a type that would be used in contract. Valid only at compile time. For having runtime safety, use `zod` types.
+ */
+export const makeType: <T>() => T extends null
+  ? ContractNullType
+  : ContractPlainType<T> = ContractPlainTypeRuntimeSymbol;
+
+/**
+ * Create route definition that would be used in contract.
+ */
+export function makeRoute<const TAppRoute extends AppRoute>(
+  route: TAppRoute,
+): TAppRoute {
+  return route;
+}
+
+/**
+ * Create a response definition that would be used for route definition in a contract.
+ */
+export function makeResponses<
+  const TResponses extends Record<
+    number,
+    ContractAnyType | ContractOtherResponse<ContractAnyType>
+  >,
+>(responses: TResponses): TResponses {
+  return responses;
+}

--- a/libs/ts-rest/express/src/lib/helpers.ts
+++ b/libs/ts-rest/express/src/lib/helpers.ts
@@ -1,0 +1,29 @@
+import { type AppRoute } from '@ts-rest/core';
+import { type AppRouteImplementation } from './types';
+
+/**
+ * Create a route implementation for the provided route type.
+ *
+ * @param impl the implementation function
+ */
+export function makeAppRouteImplementation<TAppRoute extends AppRoute>(
+  impl: AppRouteImplementation<TAppRoute>,
+): AppRouteImplementation<TAppRoute>;
+/**
+ * Create a route implementation for the provided route parameter.
+ *
+ * @param route the route to create an implementation for
+ * @param impl the implementation function
+ */
+export function makeAppRouteImplementation<TAppRoute extends AppRoute>(
+  route: TAppRoute,
+  impl: AppRouteImplementation<TAppRoute>,
+): AppRouteImplementation<TAppRoute>;
+export function makeAppRouteImplementation<TAppRoute extends AppRoute>(
+  routeOrImpl: TAppRoute | AppRouteImplementation<TAppRoute>,
+  impl?: AppRouteImplementation<TAppRoute>,
+): AppRouteImplementation<TAppRoute> {
+  if (typeof routeOrImpl === 'function') return routeOrImpl;
+  if (impl) return impl;
+  throw new Error('Invalid arguments');
+}


### PR DESCRIPTION
Motivated by few issues (like #521) and comments on Discord, I am adding few methods that will aid into easier creation of reusable endpoints/responses/implementations.

If the changes in `ts-res/express` are desired, I am willing to try to port them to other server packages.

Resolves #521