### PR TITLE
fix(core): ts-rest overwriting a supplied content-type header

### DIFF
--- a/.changeset/lovely-snails-divide.md
+++ b/.changeset/lovely-snails-divide.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': patch
+---
+
+Fix ts-rest overwriting a supplied content-type header

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -238,8 +238,8 @@ export const fetchApi = ({
         ...fetcherArgs,
         contentType: 'application/x-www-form-urlencoded',
         headers: {
-          ...fetcherArgs.headers,
           'content-type': 'application/x-www-form-urlencoded',
+          ...fetcherArgs.headers,
         },
         body:
           typeof body === 'string'
@@ -253,8 +253,8 @@ export const fetchApi = ({
         ...fetcherArgs,
         contentType: 'application/json',
         headers: {
-          ...fetcherArgs.headers,
           'content-type': 'application/json',
+          ...fetcherArgs.headers,
         },
         body: JSON.stringify(body),
       };


### PR DESCRIPTION
Fixes #531 