### PR TITLE
fix(core): invalid `extraHeaders` type when no headers are defined in the contract

### DIFF
--- a/.changeset/red-poems-guess.md
+++ b/.changeset/red-poems-guess.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': patch
+---
+
+Fix invalid `extraHeaders` type when no headers are defined in the contract

--- a/libs/ts-rest/core/src/lib/infer-types.spec.ts
+++ b/libs/ts-rest/core/src/lib/infer-types.spec.ts
@@ -107,6 +107,29 @@ const contractStrict = c.router(contract, {
   strictStatusCodes: true,
 });
 
+const headerlessContract = c.router({
+  getPost: {
+    method: 'GET',
+    path: '/posts/:id',
+    pathParams: z.object({
+      id: z.string().transform((id) => Number(id)),
+    }),
+    query: z.object({
+      includeComments: z.boolean().default(false),
+    }),
+    responses: {
+      200: z.object({
+        id: z.number(),
+        title: z.string().default('Untitled'),
+        content: z.string(),
+      }),
+      404: z.object({
+        message: z.string(),
+      }),
+    },
+  },
+});
+
 it('type inference helpers', () => {
   type ServerInferResponsesTest = Expect<
     Equal<
@@ -552,6 +575,22 @@ it('type inference helpers', () => {
             overrideClientOptions?: Partial<OverrideableClientArgs>;
             cache?: RequestCache;
           };
+        };
+      }
+    >
+  >;
+
+  type ClientInferRequestHeaderlessTest = Expect<
+    Equal<
+      ClientInferRequest<typeof headerlessContract>,
+      {
+        getPost: {
+          query: { includeComments?: boolean | undefined };
+          params: { id: string };
+          extraHeaders?: Record<string, string | undefined>;
+          fetchOptions?: FetchOptions;
+          overrideClientOptions?: Partial<OverrideableClientArgs>;
+          cache?: RequestCache;
         };
       }
     >

--- a/libs/ts-rest/core/src/lib/infer-types.ts
+++ b/libs/ts-rest/core/src/lib/infer-types.ts
@@ -217,9 +217,11 @@ type ClientInferRequestBase<
           : ZodInputOrType<T['query']>
         : never;
       headers: THeaders;
-      extraHeaders?: {
-        [K in NonNullable<keyof THeaders>]?: never;
-      } & Record<string, string | undefined>;
+      extraHeaders?: [THeaders] extends [never]
+        ? Record<string, string | undefined>
+        : {
+            [K in NonNullable<keyof THeaders>]?: never;
+          } & Record<string, string | undefined>;
       fetchOptions?: FetchOptions;
       overrideClientOptions?: Partial<OverrideableClientArgs>;
 


### PR DESCRIPTION
Fixes #530 