### PR TITLE
fix: empty response

### DIFF
--- a/.changeset/hungry-masks-carry.md
+++ b/.changeset/hungry-masks-carry.md
@@ -1,0 +1,6 @@
+---
+'@ts-rest/core': minor
+'@ts-rest/next': minor
+---
+
+fix empty result throwing parse error

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -135,6 +135,13 @@ export const router = c.router(
         200: c.type<{ message: string }>(),
       },
     },
+    emptyResponse: {
+      method: 'GET',
+      path: '/empty',
+      responses: {
+        200: c.type<void>(),
+      },
+    },
     upload: {
       method: 'POST',
       path: '/upload',
@@ -686,12 +693,14 @@ describe('client', () => {
 
       global.fetch = jest.fn(() =>
         Promise.resolve({
-          json: () =>
-            Promise.resolve({
-              id: '1',
-              name: 'John',
-              email: 'some@email',
-            }),
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({
+                id: '1',
+                name: 'John',
+                email: 'some@email',
+              }),
+            ),
           headers: new Headers({
             'content-type': 'application/json',
           }),

--- a/libs/ts-rest/next/src/lib/next-client.spec.ts
+++ b/libs/ts-rest/next/src/lib/next-client.spec.ts
@@ -52,12 +52,14 @@ describe('next-client', () => {
     });
     global.fetch = jest.fn(() =>
       Promise.resolve({
-        json: () =>
-          Promise.resolve({
-            id: '1',
-            name: 'John',
-            email: 'some@email',
-          }),
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              id: '1',
+              name: 'John',
+              email: 'some@email',
+            }),
+          ),
         headers: new Headers({
           'content-type': 'application/json',
         }),
@@ -68,7 +70,6 @@ describe('next-client', () => {
       fetchOptions: {
         next: {
           revalidate: 1,
-          tags: ['user1'],
         },
       },
     });
@@ -81,7 +82,6 @@ describe('next-client', () => {
       signal: undefined,
       next: {
         revalidate: 1,
-        tags: ['user1'],
       },
     });
     (global.fetch as jest.Mock).mockClear();


### PR DESCRIPTION
Resolves #542

Open to ideas to better handle this. Current thinking is:
- Check for `content-length` header, if there is such and the length is `0`, there is no need to try to parse (nor get) the body. 
- Instead of directly parsing to `json`, first get the `text` value and if the value is non-empty, JSON parse it.

Open to ideas to write unit test for this case. Because the `client` tests rely on mocked `fetch`, testing is not possible this way.