### PR TITLE
fix(core): broken `params` when `pathParams` is missing and zod is not installed

### DIFF
--- a/.changeset/long-colts-switch.md
+++ b/.changeset/long-colts-switch.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': patch
+---
+
+Fix `params` resolving as `any` when `pathParams` is missing and zod is not installed

--- a/libs/ts-rest/core/src/lib/infer-types.ts
+++ b/libs/ts-rest/core/src/lib/infer-types.ts
@@ -51,14 +51,14 @@ type PathParamsFromUrl<T extends AppRoute> = ParamsFromUrl<
 type PathParamsWithCustomValidators<
   T extends AppRoute,
   TClientOrServer extends 'client' | 'server' = 'server',
-> = T['pathParams'] extends undefined
-  ? PathParamsFromUrl<T>
-  : Merge<
+> = 'pathParams' extends keyof T
+  ? Merge<
       PathParamsFromUrl<T>,
       TClientOrServer extends 'server'
         ? ZodInferOrType<T['pathParams']>
         : ZodInputOrType<T['pathParams']>
-    >;
+    >
+  : PathParamsFromUrl<T>;
 
 export type ResolveResponseType<
   T extends


### PR DESCRIPTION
Fixes #365