### PR TITLE
fix: ts error when using the tsr utility on createNextHandler

### DIFF
--- a/.changeset/wild-penguins-reflect.md
+++ b/.changeset/wild-penguins-reflect.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/serverless': patch
+---
+
+Fix broken type for `@ts-rest/serverless/next` handler

--- a/libs/ts-rest/serverless/src/lib/handlers/ts-rest-next.ts
+++ b/libs/ts-rest/serverless/src/lib/handlers/ts-rest-next.ts
@@ -21,7 +21,7 @@ export type NextHandlerOptions = ServerlessHandlerOptions & {
 
 export const createNextHandler = <T extends AppRouter>(
   contract: T,
-  router: RecursiveRouterObj<T, {}>,
+  router: RecursiveRouterObj<T, NextPlatformArgs>,
   options: NextHandlerOptions,
 ) => {
   const serverlessRouter = createServerlessRouter<T, NextPlatformArgs>(


### PR DESCRIPTION
Hello, thanks for the [awesome release](https://github.com/ts-rest/ts-rest/releases/tag/v3.40.0) that adds support to Next App Router.

Everything works great but what I would like to achieve is to have multiple routers and merge them together as I instantiate the handler. I have noticed that the [serverless package does not have any docs yet](https://github.com/ts-rest/ts-rest/issues/554) and that the [linked example](https://github.com/ts-rest/ts-rest/blob/v3.40.0/apps/example-next/app/api/app-router/%5B...ts-rest%5D/route.ts) was very bare.

Basically what I'm trying to achieve is something like this:

The sample contract
```typescript
import { initContract } from '@ts-rest/core';
import { z } from 'zod';

const c = initContract();

export const contract = c.router({
  hello: {
    greet: {
      method: 'GET',
      path: '/hello/greet',
      description: 'Say hello',
      responses: {
        200: z.object({
          message: z.string(),
        }),
      },
    },
  },
});
```

Then I wanted to define a separate router under the `hello` namespace using the [tsr](https://github.com/ts-rest/ts-rest/blob/main/libs/ts-rest/serverless/src/lib/handlers/ts-rest-next.ts) utility I have found in the source code. It was exported, but I could not find any usage to it, so I assumed it's a utility function for us the end users. _Correct me if I'm wrong_

```typescript
import { tsr } from '@ts-rest/serverless/next';
import { contract } from './contract';

export const helloRouter = tsr.router(testContract.hello, {
  greet: async () => {
    return { status: 200, body: { message: 'Hi' } };
  },
});
```

I then get a TypeScript Error router when trying to put the `helloRouter` under my handler on my route handler definition saying that my `helloRouter` cannot be assigned to the expected router shape of the `createNextHandler` function.

```typescript
// app/api/[...ts-rest]/route.ts

import { createNextHandler } from '@ts-rest/serverless/next';

const handler = createNextHandler(contract, {
   hello: helloRouter // ❗TypeScript error here
}, {
    basePath: '/api',
    jsonQuery: true,
    responseValidation: true,
    handlerType: 'app-router',

})
```
Note: This only occurs when `strict` is set to `true` in `tsconfig.json`