### PR TITLE
feat (ts-rest/core): allow merging router metadata to route metadata

### DIFF
--- a/.changeset/twelve-ghosts-eat.md
+++ b/.changeset/twelve-ghosts-eat.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': minor
+---
+
+Add router-level metadata

--- a/libs/ts-rest/core/src/lib/dsl.spec.ts
+++ b/libs/ts-rest/core/src/lib/dsl.spec.ts
@@ -615,6 +615,46 @@ describe('contract', () => {
     >;
   });
 
+  it('should merge metadata options from router to its routes', () => {
+    const contract = c.router(
+      {
+        getPost: {
+          method: 'GET',
+          path: '/posts/:id',
+          responses: {
+            200: c.type<{ id: number }>(),
+          },
+        },
+        deletePost: {
+          method: 'DELETE',
+          path: '/posts/:id',
+          body: c.type<undefined>(),
+          metadata: {
+            requireAuth: false,
+            headerName: 'x-authorization'
+          },
+          responses: {
+            200: c.type<{ id: number }>(),
+          },
+        },
+      },
+      {
+        metadata: {
+          requireAuth: true
+        }
+      }
+    );
+
+    expect(contract.getPost.metadata).toStrictEqual({
+      requireAuth: true
+    });
+
+    expect(contract.deletePost.metadata).toStrictEqual({
+      requireAuth: false,
+      headerName: 'x-authorization'
+    });
+  });
+
   describe('pathPrefix', () => {
     it('Should recursively apply pathPrefix to path', () => {
       const postsContractNested = c.router(

--- a/libs/ts-rest/core/src/lib/dsl.spec.ts
+++ b/libs/ts-rest/core/src/lib/dsl.spec.ts
@@ -8,6 +8,7 @@ import {
   ContractNoBodyType,
 } from './dsl';
 import type { Equal, Expect } from './test-helpers';
+import { Prettify } from './type-utils';
 
 const c = initContract();
 
@@ -631,7 +632,7 @@ describe('contract', () => {
           body: c.type<undefined>(),
           metadata: {
             requireAuth: false,
-            headerName: 'x-authorization'
+            headerName: 'x-authorization',
           },
           responses: {
             200: c.type<{ id: number }>(),
@@ -640,19 +641,38 @@ describe('contract', () => {
       },
       {
         metadata: {
-          requireAuth: true
-        }
-      }
+          requireAuth: true,
+        },
+      },
     );
 
     expect(contract.getPost.metadata).toStrictEqual({
-      requireAuth: true
+      requireAuth: true,
     });
 
     expect(contract.deletePost.metadata).toStrictEqual({
       requireAuth: false,
-      headerName: 'x-authorization'
+      headerName: 'x-authorization',
     });
+
+    type MetadataShape = Expect<
+      Equal<
+        typeof contract.getPost.metadata,
+        {
+          requireAuth: boolean;
+        }
+      >
+    >;
+
+    type MetadataShape2 = Expect<
+      Equal<
+        Prettify<typeof contract.deletePost.metadata>,
+        {
+          requireAuth: boolean;
+          headerName: string;
+        }
+      >
+    >;
   });
 
   describe('pathPrefix', () => {

--- a/libs/ts-rest/core/src/lib/dsl.ts
+++ b/libs/ts-rest/core/src/lib/dsl.ts
@@ -145,6 +145,7 @@ type ApplyOptions<
     responses: 'commonResponses' extends keyof TOptions
       ? Prettify<Merge<TOptions['commonResponses'], TRoute['responses']>>
       : TRoute['responses'];
+    metadata: TOptions['metadata'];
   }>;
 
 /**
@@ -173,6 +174,7 @@ export type RouterOptions<TPrefix extends string = string> = {
    * @deprecated Use `validateResponse` on the client options
    */
   validateResponseOnClient?: boolean;
+  metadata?: unknown;
 };
 
 /**
@@ -273,6 +275,12 @@ const recursivelyApplyOptions = <T extends AppRouter>(
               ...options?.commonResponses,
               ...value.responses,
             },
+            metadata: options?.metadata
+              ? {
+                  ...options?.metadata,
+                  ...(value.metadata ?? {}),
+                }
+              : value.metadata,
           },
         ];
       } else {

--- a/libs/ts-rest/core/src/lib/dsl.ts
+++ b/libs/ts-rest/core/src/lib/dsl.ts
@@ -145,7 +145,9 @@ type ApplyOptions<
     responses: 'commonResponses' extends keyof TOptions
       ? Prettify<Merge<TOptions['commonResponses'], TRoute['responses']>>
       : TRoute['responses'];
-    metadata: TOptions['metadata'];
+    metadata: 'metadata' extends keyof TOptions
+      ? Prettify<Merge<TOptions['metadata'], TRoute['metadata']>>
+      : TRoute['metadata'];
   }>;
 
 /**
@@ -169,12 +171,12 @@ export type RouterOptions<TPrefix extends string = string> = {
   strictStatusCodes?: boolean;
   pathPrefix?: TPrefix;
   commonResponses?: Record<number, AppRouteResponse>;
+  metadata?: unknown;
 
   /**
    * @deprecated Use `validateResponse` on the client options
    */
   validateResponseOnClient?: boolean;
-  metadata?: unknown;
 };
 
 /**


### PR DESCRIPTION
In our project, we need a mechanism to set metadata for a whole router (and for a sub-router, of course).

Then routes inside a router can inherit this metadata.

Use case:
- A router sets metadata with:
```
{
   requireAuth: true
}
```
- Then all routes inside the router will have `requireAuth: true` along with their own metadata.