### PR TITLE
docs: clarify file upload openapi

### DIFF
--- a/apps/docs/docs/core/form-data.md
+++ b/apps/docs/docs/core/form-data.md
@@ -10,6 +10,9 @@ The contract implementation is the same as any other mutation, however, `content
 // contract.ts
 
 import { initContract } from '@ts-rest/core';
+import { extendZodWithOpenApi } from '@anatine/zod-openapi';
+
+extendZodWithOpenApi(z);
 
 const c = initContract();
 
@@ -18,7 +21,12 @@ export const postsContract = c.router({
     method: 'POST',
     path: '/posts/:id/thumbnail',
     contentType: 'multipart/form-data', // <- Only difference
+    // if you want to have the body typed
     body: c.type<{ thumbnail: File }>(), // <- Use File type in here
+    // if you care about openapi schema
+    body: z.object({
+      thumbnail: z.any().openapi({ type: 'string', format: 'binary'}),
+    }),
     responses: {
       200: z.object({
         uploadedFile: z.object({


### PR DESCRIPTION
I have lost some time looking for a way to extend the schema to handle file upload properly - correct openapi representation was worth more for me than the typed input. 
In swagger this field is displayed as a file input

https://swagger.io/docs/specification/describing-request-body/file-upload/

<img width="1476" alt="CleanShot 2024-04-17 at 13 34 23@2x" src="https://github.com/ts-rest/ts-rest/assets/26671956/fdb4ac45-2d0f-497e-b442-c2d4018ee67c">
