### PR TITLE
feat: adopt useSuspenseQuery

### DIFF
--- a/libs/ts-rest/react-query/package.json
+++ b/libs/ts-rest/react-query/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "@tanstack/react-query": "^4.0.0",
+    "@tanstack/react-query": "^4.0.0 || ^5.0.0",
     "zod": "^3.22.3"
   },
   "peerDependenciesMeta": {

--- a/libs/ts-rest/react-query/package.json
+++ b/libs/ts-rest/react-query/package.json
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "@tanstack/react-query": "^4.0.0 || ^5.0.0",
+    "@tanstack/react-query": "^4.0.0",
     "zod": "^3.22.3"
   },
   "peerDependenciesMeta": {

--- a/libs/ts-rest/react-query/src/lib/types.ts
+++ b/libs/ts-rest/react-query/src/lib/types.ts
@@ -34,10 +34,13 @@ export type ErrorResponse<TAppRoute extends AppRoute> = ClientInferResponses<
 export type UseQueryOptions<
   TAppRoute extends AppRoute,
   TData = DataResponse<TAppRoute>,
-> = TanStackUseQueryOptions<
-  DataResponse<TAppRoute>,
-  ErrorResponse<TAppRoute>,
-  TData
+> = Omit<
+  TanStackUseQueryOptions<
+    DataResponse<TAppRoute>,
+    ErrorResponse<TAppRoute>,
+    TData
+  >,
+  'queryKey'
 >;
 
 export type UseQueryResult<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,7 +582,7 @@ importers:
   libs/ts-rest/react-query:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^4.0.0
+        specifier: ^4.0.0 || ^5.0.0
         version: 4.33.0(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -13810,6 +13810,7 @@ packages:
 
   /glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
+    deprecated: Glob versions prior to v9 are no longer supported
     requiresBuild: true
     dependencies:
       inflight: 1.0.6
@@ -19694,6 +19695,7 @@ packages:
 
   /rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
     requiresBuild: true
     dependencies:


### PR DESCRIPTION
Follow-up Pull Request to https://github.com/ts-rest/ts-rest/pull/609. I removed the upgrade of the peerDependencies - so if you want to use it in your project you can add a `resolution` or `pnpm.overrides` of `"@tanstack/react-query": "^5.0.0",`