### PR TITLE
fix: fastify pathPrefix with subrouters

### DIFF
--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
@@ -298,7 +298,7 @@ const recursivelyRegisterRouter = <T extends AppRouter>(
     if (implementationIsInitialisedRouter(routerImpl)) {
       recursivelyRegisterRouter(
         routerImpl.routes,
-        routerImpl.contract,
+        appRouter,
         [...path],
         fastify,
         options,


### PR DESCRIPTION
```
const app = fastify({ logger: false });

const s = initServer();
const c = initContract();

const subContract = c.router(
  {
    getSub: {
      method: 'GET',
      path: '/get-sub',
      responses: {
        200: c.type<{ message: string }>(),
      },
    },
  },
  {
    pathPrefix: '/subroutes',
  },
);

const subRouter = s.router(subContract, {
  getSub: async () => {
    return {
      status: 200,
      body: { message: 'test' },
    };
  },
});

const mainContract = c.router(
  {
    sub: subContract,
  },
  {
    pathPrefix: '/api/v1',
  },
);

const mainRouter = s.router(mainContract, {
  sub: subRouter,
});

```
This pull request fixes the behavior of the path for sub router with pathPrefix.

**before:**
Path of subroute is `/subroutes/get-sub`

**after:**
Path of subroute is `/api/v1/subroutes/get-sub`
