### PR TITLE
Fix error Ts(2742) Update vue-query.ts

### DIFF
--- a/libs/ts-rest/vue-query/src/lib/vue-query.ts
+++ b/libs/ts-rest/vue-query/src/lib/vue-query.ts
@@ -16,7 +16,7 @@ import {
 } from './use-infinite-query';
 import { DataReturnMutation, getRouteUseMutation } from './use-mutation';
 
-type UseQueryArgs<
+export type UseQueryArgs<
   TAppRoute extends AppRoute,
   TClientArgs extends ClientArgs,
 > = {
@@ -37,7 +37,7 @@ type UseQueryArgs<
     : never;
 };
 
-type RecursiveProxyObj<T extends AppRouter, TClientArgs extends ClientArgs> = {
+export type RecursiveProxyObj<T extends AppRouter, TClientArgs extends ClientArgs> = {
   [TKey in keyof T]: T[TKey] extends AppRoute
     ? Without<UseQueryArgs<T[TKey], TClientArgs>, never>
     : T[TKey] extends AppRouter


### PR DESCRIPTION
The inferred type of 'client ' cannot be named without a reference to '@ts-rest/vue-query/src/lib/use-mutation'. This is likely not portable. A type annotation is necessary.