### PR TITLE
fix: Add License

### DIFF
--- a/libs/ts-rest/express/package.json
+++ b/libs/ts-rest/express/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ts-rest/express",
   "version": "3.45.2",
+  "license": "MIT",
   "peerDependencies": {
     "express": "^4.0.0",
     "zod": "^3.22.3"

--- a/libs/ts-rest/fastify/package.json
+++ b/libs/ts-rest/fastify/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ts-rest/fastify",
   "version": "3.45.2",
+  "license": "MIT",
   "peerDependencies": {
     "fastify": "^4.0.0",
     "zod": "^3.22.3"

--- a/libs/ts-rest/next/package.json
+++ b/libs/ts-rest/next/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ts-rest/next",
   "version": "3.45.2",
+  "license": "MIT",
   "peerDependencies": {
     "next": "^12.0.0 || ^13.0.0 || ^14.0.0",
     "zod": "^3.22.3"

--- a/libs/ts-rest/open-api/package.json
+++ b/libs/ts-rest/open-api/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ts-rest/open-api",
   "version": "3.45.2",
+  "license": "MIT",
   "dependencies": {
     "@anatine/zod-openapi": "^1.12.0",
     "openapi3-ts": "^2.0.2"

--- a/libs/ts-rest/serverless/package.json
+++ b/libs/ts-rest/serverless/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ts-rest/serverless",
   "version": "3.45.2",
+  "license": "MIT",
   "dependencies": {
     "@ts-rest/core": "3.45.2",
     "itty-router": "^5.0.9"


### PR DESCRIPTION
[ORT (OSS Review Toolkit)](https://oss-review-toolkit.org/ort/) compliance scanner fails because npm package: ts-rest:next:3.45.2 do not contain any license information

<img width="1500" alt="Screenshot 2024-07-02 at 23 42 22" src="https://github.com/ts-rest/ts-rest/assets/1210046/52a7d9a7-65cb-4c74-9dc1-90485c5e2a01">
