### PR TITLE
feat: add options for fastify route level hooks

### DIFF
--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
@@ -298,7 +298,7 @@ const recursivelyRegisterRouter = <T extends AppRouter>(
     if (implementationIsInitialisedRouter(routerImpl)) {
       recursivelyRegisterRouter(
         routerImpl.routes,
-        routerImpl.contract,
+        appRouter,
         [...path],
         fastify,
         options,


### PR DESCRIPTION
It is now possible to define fastify hooks at route level using the same principle as with ts-rest express.

```
const router = s.router(apiBlog, {
  // ...
  createPost: {
    preHandler: (request, reply, done) => {
      // some code
      console.log((request.routeConfig as { appRoute: AppRoute }).appRoute);
      done();
    },
    handler: async ({ body }) => {
      const post = mockPostFixtureFactory(body);

      return {
        status: 201,
        body: post,
      };
    },
  },
//...
});
```

All hooks that are currently possible with fastify are supported.

In addition, the contract of the respective route can be accessed in a hook with `(request.routeConfig as {appRoute: AppRoute}).appRoute`. ***This is also possible in the global hooks which are registered directly via fastify.***
