### PR TITLE
Add ts-rest metadata to Fastify Route Config

### DIFF
--- a/.changeset/metal-pumpkins-grin.md
+++ b/.changeset/metal-pumpkins-grin.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/fastify': minor
+---
+
+Add ts-rest route to fastify config object

--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
@@ -209,6 +209,7 @@ const registerRoute = <TAppRoute extends AppRoute>(
   fastify.route({
     method: appRoute.method,
     url: appRoute.path,
+    config: appRoute.metadata,
     handler: async (request, reply) => {
       const validationResults = validateRequest(
         request,

--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
@@ -15,6 +15,14 @@ import {
 } from '@ts-rest/core';
 import * as fastify from 'fastify';
 import { z } from 'zod';
+import {
+  RawServerDefault,
+  RawRequestDefaultExpression,
+  FastifySchema,
+  FastifyTypeProviderDefault,
+  RouteGenericInterface,
+  RawReplyDefaultExpression,
+} from 'fastify';
 
 export class RequestValidationError extends Error {
   constructor(
@@ -29,8 +37,21 @@ export class RequestValidationError extends Error {
 
 type AppRouteImplementation<T extends AppRoute> = (
   input: ServerInferRequest<T, fastify.FastifyRequest['headers']> & {
-    request: fastify.FastifyRequest;
-    reply: fastify.FastifyReply;
+    request: fastify.FastifyRequest<
+      RouteGenericInterface,
+      RawServerDefault,
+      RawRequestDefaultExpression,
+      FastifySchema,
+      FastifyTypeProviderDefault,
+      { tsRestRoute: T }
+    >;
+    reply: fastify.FastifyReply<
+      RawServerDefault,
+      RawRequestDefaultExpression,
+      RawReplyDefaultExpression,
+      RouteGenericInterface,
+      { tsRestRoute: T }
+    >;
     appRoute: T;
   },
 ) => Promise<ServerInferResponses<T>>;
@@ -209,7 +230,9 @@ const registerRoute = <TAppRoute extends AppRoute>(
   fastify.route({
     method: appRoute.method,
     url: appRoute.path,
-    config: appRoute.metadata,
+    config: {
+      tsRestRoute: appRoute,
+    },
     handler: async (request, reply) => {
       const validationResults = validateRequest(
         request,


### PR DESCRIPTION
Hi, I want to be able to access route `metadata` within Fastify Route's config object so that I can do authorization in global plugin/middleware that reads permission data per route. Could you please consider this PR? The change is very simple.
cc: @oliverbutler