### PR TITLE
docs: fix custom http client examples

### DIFF
--- a/apps/docs/docs/core/custom.md
+++ b/apps/docs/docs/core/custom.md
@@ -115,7 +115,7 @@ const client = initClient(contract, {
         headers,
         data: body,
       });
-      return { status: result.status, body: result.data, headers: response.headers };
+      return { status: result.status, body: result.data, headers: result.headers };
     } catch (e: Error | AxiosError | any) {
       if (isAxiosError(e)) {
         const error = e as AxiosError;
@@ -158,7 +158,7 @@ export class SampleAPI {
             headers,
             data: body,
           });
-          return { status: result.status, body: result.data, headers: response.headers };
+          return { status: result.status, body: result.data, headers: result.headers };
         } catch (e: Error | AxiosError | any) {
           if (isAxiosError(e)) {
             const error = e as AxiosError;


### PR DESCRIPTION
Minor copy-pasta error in the docs, `response` isn't defined.

It might need a cast like the `Method` above, 🤷 