### PR TITLE
fix: add OPTIONS export to nextjs app router example

### DIFF
--- a/apps/example-next/app/api/app-router/[...ts-rest]/route.ts
+++ b/apps/example-next/app/api/app-router/[...ts-rest]/route.ts
@@ -29,4 +29,5 @@ export {
   handler as PUT,
   handler as PATCH,
   handler as DELETE,
+  handler as OPTIONS,
 };


### PR DESCRIPTION
Without `export { handler as  OPTIONS }`, `ts-rest` will not be able to handle `OPTIONS` requests, and as such will e.g. not set CORS even if enabled.