### PR TITLE
fix(core): fix broken types in node + ts 5.5 when `lib.dom` is not included

### DIFF
--- a/.changeset/green-pots-laugh.md
+++ b/.changeset/green-pots-laugh.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': patch
+---
+
+Fix broken types on TS 5.5 in Node environments without `lib.dom`

--- a/libs/ts-rest/core/package.json
+++ b/libs/ts-rest/core/package.json
@@ -19,9 +19,13 @@
   },
   "license": "MIT",
   "peerDependencies": {
+    "@types/node": "^18.18.7 || >=20.8.4",
     "zod": "^3.22.3"
   },
   "peerDependenciesMeta": {
+    "@types/node": {
+      "optional": true
+    },
     "zod": {
       "optional": true
     }

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -212,7 +212,7 @@ type ClientGetPostsType = Expect<
         } & Record<string, string | undefined>;
         fetchOptions?: FetchOptions;
         overrideClientOptions?: Partial<OverrideableClientArgs>;
-        cache?: RequestCache;
+        cache?: FetchOptions['cache'];
       }
     | undefined
   >
@@ -241,7 +241,7 @@ type ClientWithoutBaseHeadersGetPostsType = Expect<
       } & Record<string, string | undefined>;
       fetchOptions?: FetchOptions;
       overrideClientOptions?: Partial<OverrideableClientArgs>;
-      cache?: RequestCache;
+      cache?: FetchOptions['cache'];
     }
   >
 >;
@@ -265,7 +265,7 @@ type ClientGetPostType = Expect<
       } & Record<string, string | undefined>;
       fetchOptions?: FetchOptions;
       overrideClientOptions?: Partial<OverrideableClientArgs>;
-      cache?: RequestCache;
+      cache?: FetchOptions['cache'];
     }
   >
 >;
@@ -773,7 +773,7 @@ describe('client', () => {
         baseUrl: 'http://localhost:5002',
       });
 
-      global.fetch = jest.fn(() =>
+      globalThis.fetch = jest.fn(() =>
         Promise.resolve({
           json: () =>
             Promise.resolve({
@@ -797,7 +797,7 @@ describe('client', () => {
         } as RequestInit,
       });
 
-      expect(global.fetch).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
         'http://localhost:5002/posts/1',
         {
           cache: undefined,
@@ -812,7 +812,7 @@ describe('client', () => {
           },
         },
       );
-      (global.fetch as jest.Mock).mockClear();
+      (globalThis.fetch as jest.Mock).mockClear();
     });
   });
 });
@@ -866,7 +866,7 @@ type CustomClientGetPostsType = Expect<
       } & Record<string, string | undefined>;
       fetchOptions?: FetchOptions;
       overrideClientOptions?: Partial<OverrideableClientArgs>;
-      cache?: RequestCache;
+      cache?: FetchOptions['cache'];
       uploadProgress?: (progress: number) => void;
     }
   >
@@ -891,7 +891,7 @@ type CustomClientGetPostType = Expect<
       } & Record<string, string | undefined>;
       fetchOptions?: FetchOptions;
       overrideClientOptions?: Partial<OverrideableClientArgs>;
-      cache?: RequestCache;
+      cache?: FetchOptions['cache'];
       uploadProgress?: (progress: number) => void;
     }
   >

--- a/libs/ts-rest/core/src/lib/infer-types.spec.ts
+++ b/libs/ts-rest/core/src/lib/infer-types.spec.ts
@@ -553,7 +553,7 @@ it('type inference helpers', () => {
           } & Record<string, string | undefined>;
           fetchOptions?: FetchOptions;
           overrideClientOptions?: Partial<OverrideableClientArgs>;
-          cache?: RequestCache;
+          cache?: FetchOptions['cache'];
         };
         createPost: {
           body: { title: string; content: string };
@@ -564,7 +564,7 @@ it('type inference helpers', () => {
           } & Record<string, string | undefined>;
           fetchOptions?: FetchOptions;
           overrideClientOptions?: Partial<OverrideableClientArgs>;
-          cache?: RequestCache;
+          cache?: FetchOptions['cache'];
         };
         uploadImage: {
           body:
@@ -580,7 +580,7 @@ it('type inference helpers', () => {
           } & Record<string, string | undefined>;
           fetchOptions?: FetchOptions;
           overrideClientOptions?: Partial<OverrideableClientArgs>;
-          cache?: RequestCache;
+          cache?: FetchOptions['cache'];
         };
         nested: {
           getComments: {
@@ -597,7 +597,7 @@ it('type inference helpers', () => {
             } & Record<string, string | undefined>;
             fetchOptions?: FetchOptions;
             overrideClientOptions?: Partial<OverrideableClientArgs>;
-            cache?: RequestCache;
+            cache?: FetchOptions['cache'];
           };
         };
       }
@@ -614,7 +614,7 @@ it('type inference helpers', () => {
           extraHeaders?: Record<string, string | undefined>;
           fetchOptions?: FetchOptions;
           overrideClientOptions?: Partial<OverrideableClientArgs>;
-          cache?: RequestCache;
+          cache?: FetchOptions['cache'];
         };
       }
     >

--- a/libs/ts-rest/core/src/lib/infer-types.ts
+++ b/libs/ts-rest/core/src/lib/infer-types.ts
@@ -242,7 +242,9 @@ type ClientInferRequestBase<
       /**
        * @deprecated Use `fetchOptions.cache` instead
        */
-      cache?: RequestCache;
+      cache?: 'cache' extends keyof TFetchOptions
+        ? TFetchOptions['cache']
+        : never;
 
       /**
        * @deprecated Use `fetchOptions.next` instead

--- a/libs/ts-rest/core/tsconfig.spec.json
+++ b/libs/ts-rest/core/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest"]
   },
   "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
 }

--- a/libs/ts-rest/next/src/lib/next-client.spec.ts
+++ b/libs/ts-rest/next/src/lib/next-client.spec.ts
@@ -39,7 +39,7 @@ describe('next-client', () => {
       extraHeaders?: Test['extraHeaders'];
       fetchOptions?: FetchOptions;
       overrideClientOptions?: Partial<OverrideableClientArgs>;
-      cache?: RequestCache;
+      cache?: FetchOptions['cache'];
       next?: FetchOptions['next'];
     };
     type NextClientTypeTest = Expect<Equal<Test, ExpectedClientArgs>>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,6 +530,9 @@ importers:
 
   libs/ts-rest/core:
     dependencies:
+      '@types/node':
+        specifier: ^18.18.7 || >=20.8.4
+        version: 18.18.7
       zod:
         specifier: ^3.22.3
         version: 3.22.3
@@ -3362,6 +3365,9 @@ packages:
 
   '@types/node@18.11.9':
     resolution: {integrity: sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==}
+
+  '@types/node@18.18.7':
+    resolution: {integrity: sha512-bw+lEsxis6eqJYW8Ql6+yTqkE6RuFtsQPSe5JxXbqYRFQEER5aJA9a5UH9igqDWm3X4iLHIKOHlnAXLM4mi7uQ==}
 
   '@types/normalize-package-data@2.4.1':
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -10006,6 +10012,9 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici@5.28.3:
     resolution: {integrity: sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==}
     engines: {node: '>=14.0'}
@@ -14811,6 +14820,10 @@ snapshots:
   '@types/node@17.0.45': {}
 
   '@types/node@18.11.9': {}
+
+  '@types/node@18.18.7':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/normalize-package-data@2.4.1': {}
 
@@ -22723,6 +22736,8 @@ snapshots:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+
+  undici-types@5.26.5: {}
 
   undici@5.28.3:
     dependencies:


### PR DESCRIPTION
Fixes #647 