### PR TITLE
feat(client): add response format options

### DIFF
--- a/libs/ts-rest/core/src/lib/client-response-error.ts
+++ b/libs/ts-rest/core/src/lib/client-response-error.ts
@@ -1,0 +1,20 @@
+import { ClientArgs } from './client';
+import { AppRoute } from './dsl';
+import { SuccessfulHttpStatusCodes } from './status-codes';
+
+export class TsRestClientResponseError<
+  TAppRoute extends AppRoute = AppRoute,
+  TClientArgs extends ClientArgs = ClientArgs,
+> extends Error {
+  constructor(
+    public appRoute: TAppRoute,
+    public response: { status: number; body: unknown; headers: Headers },
+    public clientArgs: TClientArgs,
+  ) {
+    super(
+      `Server returned unexpected response. Expected one of: ${SuccessfulHttpStatusCodes.join(
+        ',',
+      )} got: ${response.status}`,
+    );
+  }
+}

--- a/libs/ts-rest/core/src/lib/status-codes.ts
+++ b/libs/ts-rest/core/src/lib/status-codes.ts
@@ -1,12 +1,8 @@
+export const SuccessfulHttpStatusCodes = [
+  200, 201, 202, 203, 204, 205, 206, 207,
+] as const;
 export type SuccessfulHttpStatusCode =
-  | 200
-  | 201
-  | 202
-  | 203
-  | 204
-  | 205
-  | 206
-  | 207;
+  (typeof SuccessfulHttpStatusCodes)[number];
 
 /**
  * All available HTTP Status codes


### PR DESCRIPTION
When migrating to using ts-rest as the contract definitions and api client there is a lot of added boilerplate in comparison to client libraries that return the body and throw on non success response codes.

To simplify these use cases without impeding the utility of errors as values and having strictly typed response codes, I've added support for two new client options;
- `simpleResponse` option changes the behaviour to return only the body of the request as well as reflecting this in the types
- `throwOnErrorStatus` option changes the behaviour to throw on non success responses and updates the typing to reflect this

When these options are used in combination with a contract that defines basic responses e.g. `responses: { 200: c.type<User>() }` the ts-rest client can be used like a simple RPC layer e.g. `const user = await client.getUser({ params: { id } })`