### PR TITLE
feat: Enable access to TPlatformArgs in the serverless errorHandler

### DIFF
--- a/apps/example-azure-function/src/functions/index.ts
+++ b/apps/example-azure-function/src/functions/index.ts
@@ -82,6 +82,11 @@ const router = tsr.router(apiBlog, {
 const handler = createAzureFunctionHandler(apiBlog, router, {
   jsonQuery: true,
   responseValidation: true,
+  errorHandler: (err, req, { azureContext }) => {
+    if (err instanceof Error) {
+      azureContext.error(`[${err.name}] ${err.message}`);
+    }
+  },
 });
 
 app.http('apiBlog', {

--- a/libs/ts-rest/serverless/src/lib/handlers/ts-rest-azure-function.spec.ts
+++ b/libs/ts-rest/serverless/src/lib/handlers/ts-rest-azure-function.spec.ts
@@ -143,6 +143,9 @@ describe('tsRestAzureFunction', () => {
         origin: ['http://localhost'],
         credentials: true,
       },
+      errorHandler: (err, req, args) => {
+        args.azureContext.log('test');
+      },
       requestMiddleware: [
         (req: TsRestRequest & { foo: string }) => {
           req.foo = 'bar';
@@ -364,6 +367,24 @@ describe('tsRestAzureFunction', () => {
     expect(await response.text()).toEqual('');
   });
 
+  it('should have access to platformArgs in the errorHandler', async () => {
+    const httpRequest = new HttpRequest({
+      method: 'GET',
+      url: 'http://localhost/throw',
+      headers: {
+        origin: 'http://localhost',
+      },
+    });
+
+    const context = {
+      log: vi.fn(),
+    } as unknown as InvocationContext;
+
+    await azureFunctionHandler(httpRequest, context);
+
+    expect(context.log).toBeCalledWith('test');
+  });
+
   it('should handle 500 response', async () => {
     const httpRequest = new HttpRequest({
       method: 'GET',
@@ -372,6 +393,7 @@ describe('tsRestAzureFunction', () => {
         origin: 'http://localhost',
       },
     });
+
     const context = new InvocationContext({});
 
     const response = await azureFunctionHandler(httpRequest, context);

--- a/libs/ts-rest/serverless/src/lib/router.ts
+++ b/libs/ts-rest/serverless/src/lib/router.ts
@@ -370,9 +370,17 @@ const errorHandler =
   <TPlatformArgs, TRequestExtension>(
     options: ServerlessHandlerOptions<TPlatformArgs, TRequestExtension>,
   ) =>
-  async (error: unknown, request: TsRestRequest) => {
+  async (
+    error: unknown,
+    request: TsRestRequest,
+    platformArgs: TPlatformArgs,
+  ) => {
     if (options?.errorHandler) {
-      const maybeResponse = await options.errorHandler(error, request);
+      const maybeResponse = await options.errorHandler(
+        error,
+        request,
+        platformArgs,
+      );
 
       if (maybeResponse) {
         return maybeResponse;

--- a/libs/ts-rest/serverless/src/lib/types.ts
+++ b/libs/ts-rest/serverless/src/lib/types.ts
@@ -138,6 +138,7 @@ export type ServerlessHandlerOptions<
   errorHandler?: (
     err: unknown,
     req: TsRestRequest,
+    args: TPlatformArgs,
   ) => TsRestResponse | Promise<TsRestResponse> | void | Promise<void>;
   cors?: CorsOptions | false;
   basePath?: string;


### PR DESCRIPTION
### What is the change?

This change enables access to the serverless platform args in the error handler in the same way it is available in the request and response handlers.

### Why is this change important?

The primary motivation behind this change is to enable access to the Azure Functions invocation context in the error handler, ensuring that any important error-related information is logged. Azure Functions requires logging through the invocation context's methods; without this access, errors cannot be logged generically. This limitation hinders effective application monitoring and debugging and requires complicated workarounds to overcome.
