### PR TITLE
fix: AppRouteDeleteNoBody  should resolve to AppRouteQueryImplementation type

### DIFF
--- a/.changeset/odd-cooks-leave.md
+++ b/.changeset/odd-cooks-leave.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/express': patch
+---
+
+Fix route handler type for DELETE endpoints with no body

--- a/apps/example-express/src/authenticated-app.ts
+++ b/apps/example-express/src/authenticated-app.ts
@@ -137,6 +137,12 @@ const completedRouter = s.router(apiBlog, {
       };
     },
   },
+  deleteNoBody: async () => {
+    return {
+      status: 200,
+      body: { message: 'deleted' },
+    };
+  },
   testPathParams: async ({ params }) => {
     return {
       status: 200,

--- a/apps/example-express/src/authenticated-app.ts
+++ b/apps/example-express/src/authenticated-app.ts
@@ -137,12 +137,6 @@ const completedRouter = s.router(apiBlog, {
       };
     },
   },
-  deleteNoBody: async () => {
-    return {
-      status: 200,
-      body: { message: 'deleted' },
-    };
-  },
   testPathParams: async ({ params }) => {
     return {
       status: 200,

--- a/libs/example-contracts/src/lib/contract-blog.ts
+++ b/libs/example-contracts/src/lib/contract-blog.ts
@@ -64,22 +64,10 @@ export const apiBlog = c.router(
         404: z.object({ message: z.string() }),
       },
       summary: 'Delete a post',
-      body: null,
       metadata: {
         roles: ['user'],
         resource: 'post',
         identifierPath: 'params.id',
-      } as const,
-    },
-    deleteNoBody: {
-      method: 'DELETE',
-      path: `/delete-no-body`,
-      responses: {
-        200: z.object({ message: z.string() }),
-      },
-      summary: 'Delete no body',
-      metadata: {
-        roles: ['guest', 'user'],
       } as const,
     },
     getPost: {

--- a/libs/example-contracts/src/lib/contract-blog.ts
+++ b/libs/example-contracts/src/lib/contract-blog.ts
@@ -63,12 +63,23 @@ export const apiBlog = c.router(
         200: z.object({ message: z.string() }),
         404: z.object({ message: z.string() }),
       },
-      body: null,
       summary: 'Delete a post',
+      body: null,
       metadata: {
         roles: ['user'],
         resource: 'post',
         identifierPath: 'params.id',
+      } as const,
+    },
+    deleteNoBody: {
+      method: 'DELETE',
+      path: `/delete-no-body`,
+      responses: {
+        200: z.object({ message: z.string() }),
+      },
+      summary: 'Delete no body',
+      metadata: {
+        roles: ['guest', 'user'],
       } as const,
     },
     getPost: {

--- a/libs/ts-rest/express/src/lib/types.ts
+++ b/libs/ts-rest/express/src/lib/types.ts
@@ -17,7 +17,9 @@ import {
 } from 'express-serve-static-core';
 import { RequestValidationError } from './request-validation-error';
 
-export type AppRouteQueryImplementation<T extends AppRouteQuery | AppRouteDeleteNoBody> = (
+export type AppRouteQueryImplementation<
+  T extends AppRouteQuery | AppRouteDeleteNoBody,
+> = (
   input: ServerInferRequest<T, Express['request']['headers']> & {
     req: TsRestRequest<T>;
     res: Response;

--- a/libs/ts-rest/express/src/lib/types.ts
+++ b/libs/ts-rest/express/src/lib/types.ts
@@ -1,5 +1,6 @@
 import {
   AppRoute,
+  AppRouteDeleteNoBody,
   AppRouteMutation,
   AppRouteQuery,
   AppRouter,
@@ -16,7 +17,7 @@ import {
 } from 'express-serve-static-core';
 import { RequestValidationError } from './request-validation-error';
 
-export type AppRouteQueryImplementation<T extends AppRouteQuery> = (
+export type AppRouteQueryImplementation<T extends AppRouteQuery | AppRouteDeleteNoBody> = (
   input: ServerInferRequest<T, Express['request']['headers']> & {
     req: TsRestRequest<T>;
     res: Response;
@@ -35,7 +36,7 @@ export type AppRouteMutationImplementation<T extends AppRouteMutation> = (
 export type AppRouteImplementation<T extends AppRoute> =
   T extends AppRouteMutation
     ? AppRouteMutationImplementation<T>
-    : T extends AppRouteQuery
+    : T extends AppRouteQuery | AppRouteDeleteNoBody
     ? AppRouteQueryImplementation<T>
     : never;
 

--- a/libs/ts-rest/express/src/lib/types.ts
+++ b/libs/ts-rest/express/src/lib/types.ts
@@ -66,7 +66,7 @@ export type TsRestRequestHandler<T extends AppRouter | AppRoute> = (
 
 export interface AppRouteOptions<TRoute extends AppRoute> {
   middleware?: TsRestRequestHandler<TRoute>[];
-  handler: TRoute extends AppRouteQuery
+  handler: TRoute extends AppRouteQuery | AppRouteDeleteNoBody
     ? AppRouteQueryImplementation<TRoute>
     : TRoute extends AppRouteMutation
     ? AppRouteMutationImplementation<TRoute>

--- a/libs/ts-rest/react-query-v5/src/v5/types/common.ts
+++ b/libs/ts-rest/react-query-v5/src/v5/types/common.ts
@@ -1,5 +1,6 @@
 import {
   AppRoute,
+  AppRouteDeleteNoBody,
   AppRouteMutation,
   AppRouteQuery,
   AppRouter,
@@ -36,7 +37,7 @@ export type TsRestReactQueryHooksContainer<
   [TKey in keyof T]: T[TKey] extends AppRoute
     ? T[TKey] extends AppRouteQuery
       ? QueryHooks<T[TKey], TClientArgs>
-      : T[TKey] extends AppRouteMutation
+      : T[TKey] extends AppRouteMutation | AppRouteDeleteNoBody
       ? MutationHooks<T[TKey], TClientArgs>
       : never
     : T[TKey] extends AppRouter


### PR DESCRIPTION
Fixes #712.

This is mainly a fix for the typing system and does not break existing tests which was run with `pnpm nx affected:test`.