### PR TITLE
Add export to AppRouteImplementation on @ts-rest/fastify

### DIFF
--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
@@ -38,7 +38,7 @@ type FastifyContextConfig<T extends AppRouter | AppRoute> = {
   tsRestRoute: T extends AppRoute ? T : FlattenAppRouter<T>;
 };
 
-type AppRouteImplementation<T extends AppRoute> = (
+export type AppRouteImplementation<T extends AppRoute> = (
   input: ServerInferRequest<T, fastify.FastifyRequest['headers']> & {
     request: fastify.FastifyRequest<
       fastify.RouteGenericInterface,


### PR DESCRIPTION
To make possible splitting a router AppRouteImplementation should be exported to infer the types of the contract, ex:
```
const getPost: AppRouteImplementation<typeof contract.getPost> = async () => { }
```