### PR TITLE
Grouping schemas by title and referencing them on `@ts-rest/openapi`

### DIFF
--- a/.changeset/twenty-fans-reflect.md
+++ b/.changeset/twenty-fans-reflect.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/open-api': minor
+---
+
+Support automatic reusable "Components" in OpenAPI schemas, reduces final size of schema, uses the "Title" property from @anatine/zod-openapi

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
@@ -1123,7 +1123,7 @@ describe('ts-rest-open-api', () => {
 
       expect(schema).toEqual({
         components: {
-          schema: {
+          schemas: {
             Body: {
               properties: {
                 file: {
@@ -1208,7 +1208,7 @@ describe('ts-rest-open-api', () => {
 
       expect(schema).toEqual({
         components: {
-          schema: {
+          schemas: {
             Child: {
               properties: {
                 file: {

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
@@ -1,6 +1,6 @@
 import { initContract } from '@ts-rest/core';
 import { z } from 'zod';
-import { generateOpenApi } from '@ts-rest/open-api';
+import { generateOpenApi } from './ts-rest-open-api';
 import { extendApi } from '@anatine/zod-openapi';
 import { SecurityRequirementObject } from 'openapi3-ts';
 

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
@@ -393,7 +393,7 @@ export const generateOpenApi = (
 
   if (Object.keys(referenceSchemas).length) {
     apiDoc['components'] = {
-      schema: {
+      schemas: {
         ...referenceSchemas,
       },
       ...apiDoc['components'],

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
@@ -13,6 +13,7 @@ import {
   OpenAPIObject,
   OperationObject,
   PathsObject,
+  ReferenceObject,
   SchemaObject,
 } from 'openapi3-ts';
 import { generateSchema } from '@anatine/zod-openapi';
@@ -187,6 +188,72 @@ const convertSchemaObjectToMediaTypeObject = (
   };
 };
 
+const extractReferenceSchemas = (
+  schema: SchemaObject,
+  referenceSchemas: { [id: string]: SchemaObject },
+): SchemaObject => {
+  if (schema.allOf) {
+    schema.allOf = schema.allOf?.map((subSchema) =>
+      extractReferenceSchemas(subSchema, referenceSchemas),
+    );
+  }
+
+  if (schema.anyOf) {
+    schema.anyOf = schema.anyOf?.map((subSchema) =>
+      extractReferenceSchemas(subSchema, referenceSchemas),
+    );
+  }
+
+  if (schema.oneOf) {
+    schema.oneOf = schema.oneOf?.map((subSchema) =>
+      extractReferenceSchemas(subSchema, referenceSchemas),
+    );
+  }
+
+  if (schema.not) {
+    schema.not = extractReferenceSchemas(schema.not, referenceSchemas);
+  }
+
+  if (schema.items) {
+    schema.items = extractReferenceSchemas(schema.items, referenceSchemas);
+  }
+
+  if (schema.properties) {
+    schema.properties = Object.entries(schema.properties).reduce<{
+      [p: string]: SchemaObject | ReferenceObject;
+    }>((prev, [propertyName, schema]) => {
+      prev[propertyName] = extractReferenceSchemas(schema, referenceSchemas);
+      return prev;
+    }, {});
+  }
+
+  if (schema.additionalProperties) {
+    schema.additionalProperties =
+      typeof schema.additionalProperties != 'boolean'
+        ? extractReferenceSchemas(schema.additionalProperties, referenceSchemas)
+        : schema.additionalProperties;
+  }
+
+  if (schema.title) {
+    if (schema.title in referenceSchemas) {
+      if (
+        JSON.stringify(referenceSchemas[schema.title]) !==
+        JSON.stringify(schema)
+      ) {
+        throw new Error(
+          `Schema title '${schema.title}' already exists with a different schema`,
+        );
+      }
+    } else {
+      referenceSchemas[schema.title] = schema;
+    }
+    schema = {
+      $ref: `#/components/schemas/${schema.title}`,
+    };
+  }
+  return schema;
+};
+
 /**
  *
  * @param options.jsonQuery - Enable JSON query parameters, [see](/docs/open-api#json-query-params)
@@ -216,6 +283,8 @@ export const generateOpenApi = (
 
   const operationIds = new Map<string, string[]>();
 
+  const referenceSchemas: { [id: string]: SchemaObject } = {};
+
   const pathObject = paths.reduce((acc, path) => {
     if (options.setOperationId === true) {
       const existingOp = operationIds.get(path.id);
@@ -235,18 +304,29 @@ export const generateOpenApi = (
       !!options.jsonQuery,
     );
 
-    const bodySchema =
+    let bodySchema =
       path.route?.method !== 'GET' && 'body' in path.route
         ? getOpenApiSchemaFromZod(path.route.body)
         : null;
 
+    if (bodySchema?.title) {
+      bodySchema = extractReferenceSchemas(bodySchema, referenceSchemas);
+    }
+
     const responses = Object.entries(path.route.responses).reduce(
       (acc, [statusCode, response]) => {
-        const responseSchema = getOpenApiSchemaFromZod(response, true);
+        let responseSchema = getOpenApiSchemaFromZod(response, true);
         const description =
           isZodType(response) && response.description
             ? response.description
             : statusCode;
+
+        if (responseSchema) {
+          responseSchema = extractReferenceSchemas(
+            responseSchema,
+            referenceSchemas,
+          );
+        }
 
         return {
           ...acc,
@@ -310,6 +390,15 @@ export const generateOpenApi = (
 
     return acc;
   }, {} as PathsObject);
+
+  if (Object.keys(referenceSchemas).length) {
+    apiDoc['components'] = {
+      schema: {
+        ...referenceSchemas,
+      },
+      ...apiDoc['components'],
+    };
+  }
 
   return {
     openapi: '3.0.2',

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
@@ -235,6 +235,8 @@ const extractReferenceSchemas = (
   }
 
   if (schema.title) {
+    const nullable = schema.nullable;
+    schema.nullable = undefined;
     if (schema.title in referenceSchemas) {
       if (
         JSON.stringify(referenceSchemas[schema.title]) !==
@@ -247,13 +249,24 @@ const extractReferenceSchemas = (
     } else {
       referenceSchemas[schema.title] = schema;
     }
-    schema = {
-      $ref: `#/components/schemas/${schema.title}`,
-    };
+
+    if (nullable) {
+      schema = {
+        nullable: true,
+        allOf: [
+          {
+            $ref: `#/components/schemas/${schema.title}`,
+          },
+        ],
+      };
+    } else {
+      schema = {
+        $ref: `#/components/schemas/${schema.title}`,
+      };
+    }
   }
   return schema;
 };
-
 /**
  *
  * @param options.jsonQuery - Enable JSON query parameters, [see](/docs/open-api#json-query-params)


### PR DESCRIPTION
Fixes #366

By using `@anatine/zod-openapi` and setting the title property of a zod object, we can extract the schemas into `components` and reuse them around the code.

This will greatly reduce the output size of big APIs as well as generate much more compact SDKs automatically.

It assumes titles will be unique, and in case they are not, an exception will be thrown. We could use any other variable if you think it fits better.