### PR TITLE
chore: bump react peer dependency

### DIFF
--- a/.changeset/long-crews-own.md
+++ b/.changeset/long-crews-own.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/react-query-v5': minor
+---
+
+add react 19 as peer dependency

--- a/libs/ts-rest/react-query-v5/package.json
+++ b/libs/ts-rest/react-query-v5/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "zod": "^3.22.3"
   }
 }


### PR DESCRIPTION
Bumps the peer dependency of the react-query-v5 package to react 19. 
Closes https://github.com/ts-rest/ts-rest/issues/731