### PR TITLE
ci: move from 0.14 to 0.15 for nx cloud ci

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Nx Cloud - Main Job
-    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.14.0
+    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.15.0
     with:
       main-branch-name: main
       number-of-agents: 3
@@ -21,7 +21,7 @@ jobs:
 
   agents:
     name: Nx Cloud - Agents
-    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.14.0
+    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.15.0
     with:
       number-of-agents: 3
 


### PR DESCRIPTION
Move from 0.14 to 0.15 https://github.com/nrwl/ci/releases

seems we're hitting a deprecation _error_ from GH now

![image](https://github.com/user-attachments/assets/9d55b52b-550a-412b-ab54-073df0340ea8)
