### PR TITLE
fix: lock file outdated

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -619,7 +619,7 @@ importers:
         specifier: ^5.0.0
         version: 5.51.11(react@18.3.1)
       react:
-        specifier: ^16.8.0 || ^17.0.0 || ^18.0.0
+        specifier: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
         version: 18.3.1
       zod:
         specifier: ^3.22.3


### PR DESCRIPTION
Too eager on https://github.com/ts-rest/ts-rest/pull/732, missing lock file update.