### PR TITLE
fix(client): prevent unexpected end of json

### DIFF
--- a/.changeset/big-camels-complain.md
+++ b/.changeset/big-camels-complain.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': patch
+---
+
+Fix handling of responses with no body and content type json header

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -635,6 +635,31 @@ describe('client', () => {
       expect(result.headers.has('Content-Length')).toBe(false);
       expect(result.headers.has('Content-Type')).toBe(false);
     });
+
+    it('w/ undefined body and content-type json', async () => {
+      fetchMock.deleteOnce(
+        {
+          url: 'https://api.com/posts/2',
+        },
+        {
+          status: 204,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+          },
+        },
+      );
+
+      const result = await client.posts.deletePostUndefinedBody({
+        params: { id: '2' },
+      });
+
+      expect(result.body).toBeUndefined();
+      expect(result.status).toBe(204);
+      expect(result.headers.has('Content-Length')).toBe(false);
+      expect(result.headers.get('Content-Type')).toBe(
+        'application/json; charset=utf-8',
+      );
+    });
   });
 
   describe('multipart/form-data', () => {

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -1,4 +1,10 @@
-import { AppRoute, AppRouteMutation, AppRouter, isAppRoute } from './dsl';
+import {
+  AppRoute,
+  AppRouteMutation,
+  AppRouter,
+  ContractNoBody,
+  isAppRoute,
+} from './dsl';
 import { insertParamsIntoPath } from './paths';
 import { convertQueryParamsToUrlString } from './query';
 import { AreAllPropertiesOptional, Prettify } from './type-utils';
@@ -128,13 +134,14 @@ export const tsRestFetchApi: ApiFetcher = async ({
   const contentType = result.headers.get('content-type');
 
   if (contentType?.includes('application/') && contentType?.includes('json')) {
+    const responseSchema = route.responses[result.status];
+
     const response = {
       status: result.status,
-      body: await result.json(),
+      body: responseSchema === ContractNoBody ? undefined : await result.json(),
       headers: result.headers,
     };
 
-    const responseSchema = route.responses[response.status];
     if (
       (validateResponse ?? route.validateResponseOnClient) &&
       isZodType(responseSchema)


### PR DESCRIPTION
Calling `await new Response().json()` will throw an `Unexpected end of JSON input`. To prevent this issue from occurring on APIs that include the `Content-Type: application/json` header I've added a check to skip calling `response.json()` when the contract defines the status code as no body.