### PR TITLE
feat: support for RegExp in path parameters

### DIFF
--- a/libs/ts-rest/core/src/lib/paths.spec.ts
+++ b/libs/ts-rest/core/src/lib/paths.spec.ts
@@ -45,6 +45,19 @@ expectType<{
   commentId: string;
 }>(type<ParamsFromUrl<typeof urlMixedOptional2>>());
 
+const urlRegexp = '/post/:id(.*)';
+expectType<{ id: string }>(type<ParamsFromUrl<typeof urlRegexp>>());
+
+const urlMixedRegexp = '/post/:id(.*)/comments/:commentId';
+expectType<{ id: string; commentId: string }>(
+  type<ParamsFromUrl<typeof urlMixedRegexp>>(),
+);
+
+const urlManyRegexp = '/post/:id(.*)/comments/:commentId(.*)';
+expectType<{ id: string; commentId: string }>(
+  type<ParamsFromUrl<typeof urlManyRegexp>>(),
+);
+
 describe('insertParamsIntoPath', () => {
   it('should insert params into path', () => {
     const path = '/post/:id/comments/:commentId';
@@ -133,5 +146,44 @@ describe('insertParamsIntoPath', () => {
     const result = insertParamsIntoPath({ path, params });
 
     expect(result).toBe('/1');
+  });
+
+  it('should insert params into path with regex', () => {
+    const path = '/post/:id(\\d+)/comments/:commentId';
+
+    const params = {
+      commentId: '2',
+      id: '1',
+    };
+
+    const result = insertParamsIntoPath({ path, params });
+
+    expect(result).toBe('/post/1/comments/2');
+  });
+
+  it('should insert params into path with many regex', () => {
+    const path = '/post/:id(.*)/comments/:commentId(.*)';
+
+    const params = {
+      commentId: '2',
+      id: '1',
+    };
+
+    const result = insertParamsIntoPath({ path, params });
+
+    expect(result).toBe('/post/1/comments/2');
+  });
+
+  it('should insert params into path with mixed regex', () => {
+    const path = '/post/:id(.*)/comments/:commentId';
+
+    const params = {
+      commentId: '2',
+      id: '1',
+    };
+
+    const result = insertParamsIntoPath({ path, params });
+
+    expect(result).toBe('/post/1/comments/2');
   });
 });

--- a/libs/ts-rest/core/src/lib/paths.ts
+++ b/libs/ts-rest/core/src/lib/paths.ts
@@ -14,18 +14,28 @@ type ResolveOptionalPathParam<T extends string> =
 type RecursivelyExtractPathParams<
   T extends string,
   TAcc extends null | Record<string, string>,
-> = T extends `/:${infer PathParam}/${infer Right}`
+> = T extends `/:${infer PathParam}(${string})/${infer Right}`
   ? ResolveOptionalPathParam<PathParam> &
       RecursivelyExtractPathParams<Right, TAcc>
+  : T extends `/:${infer PathParam}/${infer Right}`
+  ? ResolveOptionalPathParam<PathParam> &
+      RecursivelyExtractPathParams<Right, TAcc>
+  : T extends `/:${infer PathParam}(${string})`
+  ? ResolveOptionalPathParam<PathParam>
   : T extends `/:${infer PathParam}`
   ? ResolveOptionalPathParam<PathParam>
   : T extends `/${string}/${infer Right}`
   ? RecursivelyExtractPathParams<Right, TAcc>
   : T extends `/${string}`
   ? TAcc
+  : T extends `:${infer PathParam}(${string})/${infer Right}`
+  ? ResolveOptionalPathParam<PathParam> &
+      RecursivelyExtractPathParams<Right, TAcc>
   : T extends `:${infer PathParam}/${infer Right}`
   ? ResolveOptionalPathParam<PathParam> &
       RecursivelyExtractPathParams<Right, TAcc>
+  : T extends `:${infer PathParam}(${string})`
+  ? TAcc & ResolveOptionalPathParam<PathParam>
   : T extends `:${infer PathParam}`
   ? TAcc & ResolveOptionalPathParam<PathParam>
   : T extends `${string}/${infer Right}`
@@ -64,7 +74,11 @@ export const insertParamsIntoPath = <T extends string>({
   params: ParamsFromUrl<T>;
 }) => {
   let result = path
-    .replace(PARAM_REGEX, (_, p) => (params as Record<string, string>)[p] || '')
+    .replace(PARAM_REGEX, (_, p) => {
+      const paramName = p.replace(/\(.*\)$/, '');
+
+      return (params as Record<string, string>)[paramName] || '';
+    })
     .replace(DOUBLE_SLASH_REGEX, '/');
 
   while (result.length > 1 && result.endsWith('/')) {

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
@@ -36,7 +36,7 @@ const getPathsFromRouter = (
     const value = router[key];
 
     if (isAppRoute(value)) {
-      const pathWithPathParams = value.path.replace(/:(\w+)/g, '{$1}');
+      const pathWithPathParams = value.path.replace(/\/:(\w+)[^/?]*/g, '/{$1}');
 
       paths.push({
         id: key,


### PR DESCRIPTION
Fixes #762 

This solves typing issues when using regexp by simply ignoring them when extracting path params and erasing them when inserting path params values.

Also, it fixes openapi spec generation.