### PR TITLE
fix: nextjs 404 when query params are in URL

### DIFF
--- a/.changeset/rare-elephants-itch.md
+++ b/.changeset/rare-elephants-itch.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/next': patch
+---
+
+fix: nextjs query params polute reading path params

--- a/libs/ts-rest/next/src/lib/ts-rest-next.spec.ts
+++ b/libs/ts-rest/next/src/lib/ts-rest-next.spec.ts
@@ -555,6 +555,24 @@ describe('createSingleUrlNextRouter', () => {
     });
   });
 
+  it('should send back a 200 when the query params are in the URL', async () => {
+    const resultingRouter = createSingleRouteHandler(
+      contract.getWithParams,
+      nextEndpoint.getWithParams,
+    );
+
+    const req = mockSingleUrlReq('/test/123?id=123', {
+      method: 'GET',
+    });
+
+    await resultingRouter(req, mockRes);
+
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(jsonMock).toHaveBeenCalledWith({
+      id: '123',
+    });
+  });
+
   it('should send back a 404', async () => {
     const resultingRouter = createSingleRouteHandler(
       contract.getWithParams,

--- a/libs/ts-rest/next/src/lib/ts-rest-next.ts
+++ b/libs/ts-rest/next/src/lib/ts-rest-next.ts
@@ -242,7 +242,8 @@ export function createSingleRouteHandler<T extends AppRoute>(
 ) {
   return handlerFactory((req) => {
     const route = { ...appRoute, implementation: implementationHandler };
-    const urlChunks = req.url!.split('/').slice(1);
+    // Split the URL by path and query, then split the path into chunks
+    const urlChunks = req.url!.split('?')[0].split('/').slice(1);
     const pathParams = getPathParamsFromArray(urlChunks, route);
     const query = req.query
       ? Object.fromEntries(


### PR DESCRIPTION
Currently, the final `urlChunks` item contains the query string, which prevents the route from being matched.

This PR changes the logic to omit any query params from the URL before splitting it.

fixes #697 