### PR TITLE
Add support for handling ALBEvents in the ts-rest-lambda handler

### DIFF
--- a/libs/ts-rest/serverless/src/lib/handlers/ts-rest-lambda.spec.ts
+++ b/libs/ts-rest/serverless/src/lib/handlers/ts-rest-lambda.spec.ts
@@ -816,4 +816,78 @@ describe('tsRestLambda', () => {
       isBase64Encoded: false,
     });
   });
+
+  // ALB Event Tests
+  describe('ALB Events', () => {
+    let albEvent: any;
+
+    beforeEach(() => {
+      albEvent = {
+        requestContext: {
+          elb: {
+            targetGroupArn: 'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/test-target-group/1234567890abcdef'
+          }
+        },
+        httpMethod: 'GET',
+        path: '/test',
+        queryStringParameters: {
+          foo: 'bar'
+        },
+        headers: {
+          'content-type': 'application/json',
+          'origin': 'http://localhost'
+        },
+        body: '',
+        isBase64Encoded: false
+      };
+    });
+
+    it('should handle GET request with ALB event', async () => {
+      const response = await lambdaHandler(albEvent, {} as Context);
+      expect(response).toEqual({
+        statusCode: 200,
+        headers: {
+          'access-control-allow-credentials': 'true',
+          'access-control-allow-origin': 'http://localhost',
+          'content-type': 'application/json',
+          vary: 'Origin',
+        },
+        multiValueHeaders: {
+          'access-control-allow-credentials': ['true'],
+          'access-control-allow-origin': ['http://localhost'],
+          'content-type': ['application/json'],
+          vary: ['Origin'],
+        },
+        body: '{"foo":"bar"}',
+        isBase64Encoded: false,
+      });
+    });
+
+    it('should handle POST request with ALB event', async () => {
+      albEvent.httpMethod = 'POST';
+      albEvent.path = '/ping/123';
+      albEvent.body = '{"ping":"foo"}';
+
+      const response = await lambdaHandler(albEvent, {} as Context);
+      expect(response).toEqual({
+        statusCode: 200,
+        headers: {
+          'access-control-allow-credentials': 'true',
+          'access-control-allow-origin': 'http://localhost',
+          'cache-control': 'no-cache, no-store',
+          'content-type': 'application/json',
+          vary: 'Origin',
+        },
+        multiValueHeaders: {
+          'access-control-allow-credentials': ['true'],
+          'access-control-allow-origin': ['http://localhost'],
+          'cache-control': ['no-cache', 'no-store'],
+          'content-type': ['application/json'],
+          vary: ['Origin'],
+        },
+        body: '{"id":"123","pong":"foo"}',
+        isBase64Encoded: false,
+      });
+    });
+  });
 });

--- a/libs/ts-rest/serverless/src/lib/handlers/ts-rest-lambda.ts
+++ b/libs/ts-rest/serverless/src/lib/handlers/ts-rest-lambda.ts
@@ -1,26 +1,41 @@
-import type { Context } from 'aws-lambda';
-import { AppRouter } from '@ts-rest/core';
-import {
+import type { ALBEvent, Context } from 'aws-lambda';
+import type { AppRouter } from '@ts-rest/core';
+import type {
   ApiGatewayEvent,
   ApiGatewayResponse,
-  requestFromEvent,
-  responseToResult,
 } from '../mappers/aws/api-gateway';
-import { createServerlessRouter } from '../router';
 import {
-  createTsr,
+  isV2,
+  requestFromEvent as apiGatewayRequestFromEvent,
+  responseToResult as apiGatewayResponseToResult,
+} from '../mappers/aws/api-gateway';
+import type {
+  AlbEvent,
+  AlbResponse,
+} from '../mappers/aws/alb';
+import {
+  isAlbEvent,
+  requestFromEvent as albRequestFromEvent,
+  responseToResult as albResponseToResult,
+} from '../mappers/aws/alb';
+import { createServerlessRouter } from '../router';
+import type {
   RouterImplementationOrFluentRouter,
   ServerlessHandlerOptions,
 } from '../types';
+import { createTsr } from '../types';
+
+type EventType = ApiGatewayEvent | AlbEvent;
+type ResponseType = ApiGatewayResponse | AlbResponse;
 
 type LambdaPlatformArgs = {
-  rawEvent: ApiGatewayEvent;
+  rawEvent: EventType;
   lambdaContext: Context;
 };
 
 export const tsr = createTsr<LambdaPlatformArgs>();
 
-export type LambdaHandlerOptions<TRequestExtension = {}> =
+export type LambdaHandlerOptions<TRequestExtension = Record<string, unknown>> =
   ServerlessHandlerOptions<LambdaPlatformArgs, TRequestExtension>;
 
 export const createLambdaHandler = <T extends AppRouter, TRequestExtension>(
@@ -39,18 +54,22 @@ export const createLambdaHandler = <T extends AppRouter, TRequestExtension>(
   >(contract, router, options);
 
   return async (
-    event: ApiGatewayEvent,
+    event: EventType,
     context: Context,
-  ): Promise<ApiGatewayResponse> => {
-    const request = requestFromEvent(event);
+  ): Promise<ResponseType> => {
+    const request = isAlbEvent(event)
+      ? albRequestFromEvent(event as AlbEvent)
+      : apiGatewayRequestFromEvent(event as ApiGatewayEvent);
 
-    return serverlessRouter
-      .fetch(request, {
-        rawEvent: event,
-        lambdaContext: context,
-      })
-      .then(async (response) => {
-        return responseToResult(event, response);
-      });
+    const response = await serverlessRouter.fetch(request, {
+      rawEvent: event,
+      lambdaContext: context,
+    });
+
+    if (isAlbEvent(event)) {
+      return albResponseToResult(response);
+    }
+
+    return apiGatewayResponseToResult(event as ApiGatewayEvent, response);
   };
 };

--- a/libs/ts-rest/serverless/src/lib/mappers/aws/alb.spec.ts
+++ b/libs/ts-rest/serverless/src/lib/mappers/aws/alb.spec.ts
@@ -1,0 +1,123 @@
+import {
+  isAlbEvent,
+  requestBody,
+  requestFromEvent,
+  requestHeaders,
+  requestMethod,
+  requestRemoteAddress,
+  requestUrl,
+} from './alb';
+import * as albEvent from './test-data/alb-event.json';
+import * as albPostEvent from './test-data/alb-post-event.json';
+import * as apiGatewayEventV1 from './test-data/api-gateway-event-v1.json';
+
+const headerToObject = (headers: Headers) => {
+  const obj: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    obj[key] = value;
+  });
+  return obj;
+};
+
+describe('ALB', () => {
+  describe('isAlbEvent', () => {
+    it('should return true for ALB event', () => {
+      expect(isAlbEvent(albEvent)).toBe(true);
+    });
+
+    it('should return false for API Gateway event', () => {
+      expect(isAlbEvent(apiGatewayEventV1)).toBe(false);
+    });
+  });
+
+  describe('requestMethod', () => {
+    it('should work for ALB event', () => {
+      expect(requestMethod(albEvent as any)).toBe('GET');
+    });
+  });
+
+  describe('requestRemoteAddress', () => {
+    it('should work for ALB event', () => {
+      expect(requestRemoteAddress(albEvent as any)).toBe(
+        'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/test-target-group/1234567890abcdef'
+      );
+    });
+  });
+
+  describe('requestHeaders', () => {
+    it('should work for ALB event', () => {
+      expect(headerToObject(requestHeaders(albEvent as any))).toEqual({
+        accept: '*/*',
+        'content-type': 'application/json',
+        host: 'example.com',
+        'user-agent': 'curl/7.58.0',
+        'x-forwarded-for': '192.168.0.1',
+        'x-forwarded-port': '443',
+        'x-forwarded-proto': 'https',
+      });
+    });
+  });
+
+  describe('requestBody', () => {
+    it('should return empty for GET request', () => {
+      const body = requestBody(albEvent as any);
+      expect(body).toBe('');
+    });
+
+    it('should work for POST request', () => {
+      const body = requestBody(albPostEvent as any);
+      expect(body).toBe('{"name":"Test Item"}');
+    });
+  });
+
+  describe('requestUrl', () => {
+    it('should work for ALB event', () => {
+      expect(requestUrl(albEvent as any)).toBe(
+        'http://localhost/test?foo=bar'
+      );
+    });
+
+    it('should work for POST ALB event with no query params', () => {
+      expect(requestUrl(albPostEvent as any)).toBe(
+        'http://localhost/api/items'
+      );
+    });
+  });
+
+  describe('requestFromEvent', () => {
+    it('should work for ALB event', () => {
+      const request = requestFromEvent(albEvent as any);
+
+      expect(request.method).toEqual('GET');
+      expect(request.url).toEqual('http://localhost/test?foo=bar');
+      expect(headerToObject(request.headers)).toEqual({
+        accept: '*/*',
+        'content-type': 'application/json',
+        host: 'example.com',
+        'user-agent': 'curl/7.58.0',
+        'x-forwarded-for': '192.168.0.1',
+        'x-forwarded-port': '443',
+        'x-forwarded-proto': 'https',
+      });
+      expect(request.body).toEqual(null);
+    });
+
+    it('should work for POST ALB event', async () => {
+      const request = requestFromEvent(albPostEvent as any);
+
+      expect(request.method).toEqual('POST');
+      expect(request.url).toEqual('http://localhost/api/items');
+      expect(headerToObject(request.headers)).toEqual({
+        accept: 'application/json',
+        'content-type': 'application/json',
+        host: 'example.com',
+        'user-agent': 'curl/7.58.0',
+        'x-forwarded-for': '192.168.0.1',
+        'x-forwarded-port': '443',
+        'x-forwarded-proto': 'https',
+        'content-length': '25',
+      });
+      expect(await request.text()).toEqual('{"name":"Test Item"}');
+    });
+  });
+});

--- a/libs/ts-rest/serverless/src/lib/mappers/aws/alb.ts
+++ b/libs/ts-rest/serverless/src/lib/mappers/aws/alb.ts
@@ -1,0 +1,144 @@
+import type { ALBEvent, ALBResult } from 'aws-lambda';
+import { TsRestRequest } from '../../request';
+import type { TsRestResponse } from '../../response';
+import {
+  arrayBufferToBase64,
+  arrayBufferToString,
+  splitCookiesString,
+} from '../../utils';
+
+export type AlbEvent = ALBEvent;
+export type AlbResponse = ALBResult;
+
+export function isAlbEvent(event: unknown): event is AlbEvent {
+  return typeof event === 'object' &&
+         event !== null &&
+         'requestContext' in event &&
+         typeof event.requestContext === 'object' &&
+         event.requestContext !== null &&
+         'elb' in event.requestContext;
+}
+
+export function requestMethod(event: AlbEvent) {
+  return event.httpMethod;
+}
+
+export function requestRemoteAddress(event: AlbEvent) {
+  return event.requestContext?.elb?.targetGroupArn || '';
+}
+
+export function requestHeaders(event: AlbEvent) {
+  const headers = new Headers();
+
+  if (event.multiValueHeaders) {
+    for (const [key, values] of Object.entries(event.multiValueHeaders)) {
+      if (values) {
+        for (const value of values) {
+          headers.append(key, value);
+        }
+      }
+    }
+  }
+
+  if (event.headers) {
+    for (const [key, value] of Object.entries(event.headers)) {
+      if (value) {
+        headers.set(key, value);
+      } else {
+        headers.delete(key);
+      }
+    }
+  }
+
+  return headers;
+}
+
+export function requestBody(event: AlbEvent): ArrayBuffer | string | undefined {
+  if (event.body === undefined || event.body === null) {
+    return;
+  }
+
+  if (event.isBase64Encoded) {
+    return Buffer.from(event.body, 'base64');
+  }
+
+  return event.body;
+}
+
+export function requestUrl(event: AlbEvent) {
+  const url = new URL(event.path, 'http://localhost');
+
+  if (event.multiValueQueryStringParameters) {
+    for (const [key, values] of Object.entries(event.multiValueQueryStringParameters)) {
+      if (values) {
+        for (const value of values) {
+          url.searchParams.append(key, value);
+        }
+      }
+    }
+  }
+
+  if (event.queryStringParameters) {
+    for (const [key, value] of Object.entries(event.queryStringParameters)) {
+      if (value) {
+        url.searchParams.set(key, value);
+      } else {
+        url.searchParams.delete(key);
+      }
+    }
+  }
+
+  return url.href;
+}
+
+export function requestFromEvent(event: AlbEvent) {
+  return new TsRestRequest(requestUrl(event), {
+    method: requestMethod(event),
+    headers: requestHeaders(event),
+    body: requestBody(event),
+  });
+}
+
+export async function responseToResult(
+  response: TsRestResponse,
+): Promise<AlbResponse> {
+  const headers: Record<string, string> = {};
+  const multiValueHeaders: Record<string, string[]> = {};
+
+  response.headers.forEach((value, key) => {
+    headers[key] = headers[key] ? `${headers[key]}, ${value}` : value;
+
+    const multiValueHeaderValue =
+      key === 'set-cookie'
+        ? splitCookiesString(value)
+        : value.split(',').map((v) => v.trim());
+
+    multiValueHeaders[key] = multiValueHeaders[key]
+      ? [...multiValueHeaders[key], ...multiValueHeaderValue]
+      : multiValueHeaderValue;
+  });
+
+  let isBase64Encoded = false;
+  let body: string;
+
+  if (typeof response.rawBody === 'string' || response.rawBody === null) {
+    body = response.rawBody ?? '';
+  } else if (
+    headers['content-type']?.startsWith('text/') ||
+    (response.rawBody instanceof Blob &&
+      response.rawBody.type.startsWith('text/'))
+  ) {
+    body = await arrayBufferToString(response.rawBody);
+  } else {
+    body = await arrayBufferToBase64(response.rawBody);
+    isBase64Encoded = true;
+  }
+
+  return {
+    statusCode: response.status,
+    headers,
+    multiValueHeaders,
+    body,
+    isBase64Encoded,
+  };
+}

--- a/libs/ts-rest/serverless/src/lib/mappers/aws/test-data/alb-event.json
+++ b/libs/ts-rest/serverless/src/lib/mappers/aws/test-data/alb-event.json
@@ -1,0 +1,23 @@
+{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/test-target-group/1234567890abcdef"
+    }
+  },
+  "httpMethod": "GET",
+  "path": "/test",
+  "queryStringParameters": {
+    "foo": "bar"
+  },
+  "headers": {
+    "accept": "*/*",
+    "content-type": "application/json",
+    "host": "example.com",
+    "user-agent": "curl/7.58.0",
+    "x-forwarded-for": "192.168.0.1",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https"
+  },
+  "body": "",
+  "isBase64Encoded": false
+}

--- a/libs/ts-rest/serverless/src/lib/mappers/aws/test-data/alb-post-event.json
+++ b/libs/ts-rest/serverless/src/lib/mappers/aws/test-data/alb-post-event.json
@@ -1,0 +1,22 @@
+{
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/test-target-group/1234567890abcdef"
+    }
+  },
+  "httpMethod": "POST",
+  "path": "/api/items",
+  "queryStringParameters": null,
+  "headers": {
+    "accept": "application/json",
+    "content-type": "application/json",
+    "host": "example.com",
+    "user-agent": "curl/7.58.0",
+    "x-forwarded-for": "192.168.0.1",
+    "x-forwarded-port": "443",
+    "x-forwarded-proto": "https",
+    "content-length": "25"
+  },
+  "body": "{\"name\":\"Test Item\"}",
+  "isBase64Encoded": false
+}


### PR DESCRIPTION
This PR allows for passing ALBEvents to the handler created by `createLambdaHandler` in `ts-rest-lambda`.