### PR TITLE
feat: Export Fastify AppRouteImplementation and AppRouteImplementationOrOptions types to allow typed, scalable router files

### DIFF
--- a/.changeset/plenty-seahorses-wait.md
+++ b/.changeset/plenty-seahorses-wait.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/fastify': minor
+---
+
+export AppRouteImplementation from fastify to allow for usage cross-file

--- a/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
+++ b/libs/ts-rest/fastify/src/lib/ts-rest-fastify.ts
@@ -38,7 +38,7 @@ type FastifyContextConfig<T extends AppRouter | AppRoute> = {
   tsRestRoute: T extends AppRoute ? T : FlattenAppRouter<T>;
 };
 
-type AppRouteImplementation<T extends AppRoute> = (
+export type AppRouteImplementation<T extends AppRoute> = (
   input: ServerInferRequest<T, fastify.FastifyRequest['headers']> & {
     request: fastify.FastifyRequest<
       fastify.RouteGenericInterface,
@@ -128,7 +128,7 @@ type AppRouteOptions<TRoute extends AppRoute> = {
   handler: AppRouteImplementation<TRoute>;
 };
 
-type AppRouteImplementationOrOptions<TRoute extends AppRoute> =
+export type AppRouteImplementationOrOptions<TRoute extends AppRoute> =
   | AppRouteOptions<TRoute>
   | AppRouteImplementation<TRoute>;
 


### PR DESCRIPTION
I'm making this change so that I can support creating multiple route files and keep them typed. The AppRouteImplementation is already being [exported in the @ts-rest/express package](https://github.com/ts-rest/ts-rest/blob/fee9fbf348cce38b83e2450d5ac0b033dd13abd1/libs/ts-rest/express/src/lib/types.ts#L38-L43) so this is just mimicking that functionality.

Intended use-case example ([adapted from the Usage example for Fastify](https://ts-rest.com/docs/fastify#usage)):
```
import Fastify from 'fastify'
import { initServer } from '@ts-rest/fastify'
import { getPost } from './routes/getPost.ts'
import { createPost } from './routes/createPost.ts'

const app = Fastify()

const s = initServer()

const router = s.router(contract, {
  getPost,
  createPost,
})

app.register(s.plugin(router))

const start = async () => {
  try {
    await app.listen({ port: 3000 })
  } catch (err) {
    app.log.error(err)
    process.exit(1)
  }
}

start()
```

`// "../routes/getPost.ts";`
```
import { type AppRouteImplementation } from '@ts-rest/fastify'

export const getPost: AppRouteImplementation<typeof contract.getPost> = async ({
  params: { id },
}) => {
  const post = await prisma.post.findUnique({ where: { id } })

  return {
    status: 200,
    body: post,
  }
}
```

`// "../routes/createPost.ts";`
```
import { type AppRouteImplementation } from '@ts-rest/fastify'
import { contract } from '@repo/ts-rest'

export const getPost: AppRouteImplementation<
  typeof contract.createPost
> = async ({ body }) => {
  const post = await prisma.post.create({
    data: body,
  })

  return {
    status: 201,
    body: post,
  }
}
```