### PR TITLE
Update troubleshoot.md with potential LSP speed issue fix

### DIFF
--- a/apps/docs/docs/troubleshoot.md
+++ b/apps/docs/docs/troubleshoot.md
@@ -20,3 +20,13 @@ If you cannot use `strict` entirely, you'll need to at least enable `strictNullC
 
 This is required as part of [Zod](https://github.com/colinhacks/zod#requirements). See why [here](https://github.com/colinhacks/zod/issues/1750).
 
+Additionally, if you're using a monorepo, make sure the contract's package exports the built files and not the Typescript files:
+
+```
+  "exports": {
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
+    }
+  }
+```


### PR DESCRIPTION
Started a new project, picked TS-Rest, the team loves it - but after 15-20 endpoints the Typescript LSP took between 10 and 30 seconds for simple autocomplete suggestions. This is on beefy machines too. Browsing the docs was fruitless, searching the Discord was fruitless. Only after browsing tRPC's issues on Github did I realize I was actually exporting source (src/\*.ts) files instead of the built (dist/\*.d.ts) files. Switching the exports over dropped the suggestion delay times from ~20s to ~2s. Having this suggestion might be helpful for people in similar situations.