### PR TITLE
fix(serverless): inferred types not portable

### DIFF
--- a/libs/ts-rest/serverless/src/index.ts
+++ b/libs/ts-rest/serverless/src/index.ts
@@ -1,5 +1,14 @@
 export * from './lib/http-error';
 export * from './lib/request';
 export * from './lib/response';
-export { RequestValidationError, ResponseValidationError } from './lib/types';
+export {
+  RequestValidationError,
+  ResponseValidationError,
+  type AppRouteImplementation,
+  type AppRouteImplementationOrOptions,
+  type AppRouteOptions,
+  type RouterImplementation,
+  type RouterImplementationOrFluentRouter,
+  type ServerlessHandlerOptions,
+} from './lib/types';
 export { RouterBuilder, CompleteRouter } from './lib/router-builder';


### PR DESCRIPTION
When building with `verbatimModuleSyntax` (which enables `isolatedModules`) I get the following error:

```
error TS2742: The inferred type of 'Router' cannot be named without a reference to 'packages/ts-rest/node_modules/@ts-rest/serverless/src/lib/types.js'. This is likely not portable. A type annotation is necessary.
```

To solve this I have previously been deep importing types from `@ts-rest/serverless/src/lib/types` to manually annotate with the correct types. But this does not work when `moduleResolution` is set to more modern values such as `nodenext`. So to avoid this error entirely we can export the required types. 