### PR TITLE
fix(openapi): expose path id to operation mapper

### DIFF
--- a/.changeset/shy-vans-float.md
+++ b/.changeset/shy-vans-float.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/open-api': minor
+---
+
+Add operation ID parameter to operationMapper function, allowing using the appRoute's id in the callback.

--- a/apps/docs/docs/open-api.mdx
+++ b/apps/docs/docs/open-api.mdx
@@ -97,7 +97,7 @@ You can see an example of its usage in the code snippet above.
 
 We do not provide first-party support to set all possible OpenAPI fields on the operations such as the `security` field. In addition, you may have some specific needs to modify the fields already set by `ts-rest` such as the `tags` field.
 
-Therefore, we have provided an `operationMapper` option to allow you to modify the OpenAPI fields of the operations. This is a callback function, that will receive the operation object and the contract endpoint, and must return a valid OpenAPI operation object.
+Therefore, we have provided an `operationMapper` option to allow you to modify the OpenAPI fields of the operations. This is a callback function, that will receive the operation object, the contract endpoint, and the operation ID, and must return a valid OpenAPI operation object.
 A common way to provide data to this function is to utilize the `metadata` field of the contract endpoint. However, feel free to come up with a different solution to doing this if you would not like to include this data in your contracts.
 
 ```typescript
@@ -105,9 +105,7 @@ const hasCustomTags = (
   metadata: unknown,
 ): metadata is { openApiTags: string[] } => {
   return (
-    !!metadata &&
-    typeof metadata === 'object' &&
-    'openApiTags' in metadata
+    !!metadata && typeof metadata === 'object' && 'openApiTags' in metadata
   );
 };
 
@@ -115,9 +113,7 @@ const hasSecurity = (
   metadata: unknown,
 ): metadata is { openApiSecurity: SecurityRequirementObject[] } => {
   return (
-    !!metadata &&
-    typeof metadata === 'object' &&
-    'openApiSecurity' in metadata
+    !!metadata && typeof metadata === 'object' && 'openApiSecurity' in metadata
   );
 };
 
@@ -135,7 +131,7 @@ const apiDoc = generateOpenApi(
     },
   },
   {
-    operationMapper: (operation, appRoute) => ({
+    operationMapper: (operation, appRoute, id) => ({
       ...operation,
       ...(hasCustomTags(appRoute.metadata)
         ? {
@@ -147,6 +143,8 @@ const apiDoc = generateOpenApi(
             security: appRoute.metadata.openApiSecurity,
           }
         : {}),
+      // You can also use the operation ID for custom logic
+      description: `${operation.description || ''} (Operation: ${id})`,
     }),
   },
 );
@@ -213,12 +211,13 @@ const openApiDocument = generateOpenApi(myContract, {
   },
 });
 
-app.register(fastifySwagger, {
-  transformObject: () => openApiDocument
-})
-.register(fastifySwaggerUI, {
-  routePrefix: '/api-docs',
-});
+app
+  .register(fastifySwagger, {
+    transformObject: () => openApiDocument,
+  })
+  .register(fastifySwaggerUI, {
+    routePrefix: '/api-docs',
+  });
 ```
 
 Don't worry if you don't use express or Nest, whatever library you want to use is OK our OpenAPI returns a plain JSON object which is fully compliant with the OpenAPI spec.

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
@@ -857,6 +857,52 @@ describe('ts-rest-open-api', () => {
       });
     });
 
+    it('should pass operation id to operationMapper', async () => {
+      const operationIds: string[] = [];
+
+      const apiDoc = generateOpenApi(
+        router,
+        {
+          info: { title: 'Blog API', version: '0.1' },
+        },
+        {
+          operationMapper: (operation, appRoute, id) => {
+            operationIds.push(id);
+            return {
+              ...operation,
+              'x-operation-id': id, // Add the id as a custom field for verification
+            };
+          },
+        },
+      );
+
+      // Verify that operation IDs were collected
+      expect(operationIds).toContain('health');
+      expect(operationIds).toContain('mediaExamples');
+      expect(operationIds).toContain('findPosts');
+      expect(operationIds).toContain('createPost');
+      expect(operationIds).toContain('getPost');
+      expect(operationIds).toContain('getPostComments');
+      expect(operationIds).toContain('getPostComment');
+      expect(operationIds).toContain('auth');
+
+      // Verify that the custom field was added with the correct id
+      expect(apiDoc.paths['/health'].get['x-operation-id']).toBe('health');
+      expect(apiDoc.paths['/posts'].get['x-operation-id']).toBe('findPosts');
+      expect(apiDoc.paths['/posts'].post['x-operation-id']).toBe('createPost');
+      expect(apiDoc.paths['/posts/{id}'].get['x-operation-id']).toBe('getPost');
+      expect(apiDoc.paths['/posts/{id}/comments'].get['x-operation-id']).toBe(
+        'getPostComments',
+      );
+      expect(
+        apiDoc.paths['/posts/{id}/comments/{commentId}'].get['x-operation-id'],
+      ).toBe('getPostComment');
+      expect(apiDoc.paths['/auth'].post['x-operation-id']).toBe('auth');
+      expect(apiDoc.paths['/media-examples'].post['x-operation-id']).toBe(
+        'mediaExamples',
+      );
+    });
+
     it('works with zod refine', () => {
       const routerWithRefine = c.router({
         endpointWithZodRefine: {

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
@@ -268,9 +268,15 @@ const extractReferenceSchemas = (
   return schema;
 };
 /**
+ * Generate OpenAPI specification from ts-rest router
  *
+ * @param router - The ts-rest router to generate OpenAPI from
+ * @param apiDoc - Base OpenAPI document configuration
+ * @param options - Generation options
+ * @param options.setOperationId - Whether to set operation IDs (true, false, or 'concatenated-path')
  * @param options.jsonQuery - Enable JSON query parameters, [see](/docs/open-api#json-query-params)
- * @returns
+ * @param options.operationMapper - Function to customize OpenAPI operations. Receives the operation object, app route, and operation ID
+ * @returns OpenAPI specification object
  */
 export const generateOpenApi = (
   router: AppRouter,

--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts
@@ -281,6 +281,7 @@ export const generateOpenApi = (
     operationMapper?: (
       operation: OperationObject,
       appRoute: AppRoute,
+      id: string,
     ) => OperationObject;
   } = {},
 ): OpenAPIObject => {
@@ -397,7 +398,7 @@ export const generateOpenApi = (
     acc[path.path] = {
       ...acc[path.path],
       [mapMethod[path.route.method]]: options.operationMapper
-        ? options.operationMapper(pathOperation, path.route)
+        ? options.operationMapper(pathOperation, path.route, path.id)
         : pathOperation,
     };
 


### PR DESCRIPTION
This pull request updates the `generateOpenApi` function in the `ts-rest-open-api` library to enhance its flexibility by adding an additional parameter to the `operationMapper` callback. The new parameter provides more context for mapping operations.

### Enhancements to `generateOpenApi`:

* Updated the `operationMapper` callback signature to include a new `id` parameter, allowing it to receive the `id` of the route being processed. (`libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts`, [libs/ts-rest/open-api/src/lib/ts-rest-open-api.tsR284](diffhunk://#diff-393f1f67c72980bbf00be005d8b28a2e878a2d934467ffe9f50b749a66a89ab7R284))
* Modified the invocation of `operationMapper` to pass the `id` parameter from the `path` object, ensuring the callback has access to this additional context. (`libs/ts-rest/open-api/src/lib/ts-rest-open-api.ts`, [libs/ts-rest/open-api/src/lib/ts-rest-open-api.tsL400-R401](diffhunk://#diff-393f1f67c72980bbf00be005d8b28a2e878a2d934467ffe9f50b749a66a89ab7L400-R401))

Fixes: https://github.com/ts-rest/ts-rest/issues/802