### PR TITLE
fix(core): remove extra forward slash

### DIFF
--- a/.changeset/rich-coins-move.md
+++ b/.changeset/rich-coins-move.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': patch
+---
+
+Fixed a bug where leading and trailing forward slashes the baseUrl and path would double up

--- a/libs/ts-rest/core/src/lib/client.spec.ts
+++ b/libs/ts-rest/core/src/lib/client.spec.ts
@@ -179,7 +179,7 @@ const routerStrict = c.router(router, {
 });
 
 const client = initClient(router, {
-  baseUrl: 'https://api.com',
+  baseUrl: 'https://api.com/',
   baseHeaders: {
     'X-Api-Key': 'foo',
   },

--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -391,6 +391,11 @@ export const getCompleteUrl = (
     params: params as any,
   });
   const queryComponent = convertQueryParamsToUrlString(query, jsonQuery);
+
+  if (baseUrl.endsWith('/') && path.startsWith('/')) {
+    return `${baseUrl}${path.substring(1)}${queryComponent}`;
+  }
+
   return `${baseUrl}${path}${queryComponent}`;
 };
 


### PR DESCRIPTION
Fixed a bug where leading and trailing forward slashes the baseUrl and path would double up.