### PR TITLE
fix: 3.53.0-rc.0 bug with Zod4's `coerce`

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -22,7 +22,7 @@ export default function Layout({ children }: { children: any }) {
         <PostHogProvider>
           <Banner variant="rainbow" id="3-53-0-release">
             Zod 4 (and all other Standard Schema support) is available as a
-            release candidate `3.53.0-rc.0`
+            release candidate `3.53.0-rc.1`
           </Banner>
           <RootProvider>{children}</RootProvider>
           <CookieBanner />

--- a/libs/ts-rest/core/src/lib/dsl.spec.ts
+++ b/libs/ts-rest/core/src/lib/dsl.spec.ts
@@ -1424,7 +1424,7 @@ describe('header types', () => {
       };
 
       type Actual = InferHeadersInput<typeof route.getPost, typeof headers>;
-      type TestResult = Expect<Equal<Actual, { 'x-foo': string | undefined }>>;
+      type TestResult = Expect<Equal<Actual, { 'x-foo'?: string | undefined }>>;
     });
 
     it('should handle optional headers with base headers', () => {

--- a/libs/ts-rest/core/src/lib/dsl.ts
+++ b/libs/ts-rest/core/src/lib/dsl.ts
@@ -237,13 +237,35 @@ export type InferHeadersInput<
   ? LowercaseKeys<z.input<THeaders>>
   : // if modern object-based headers
   THeaders extends Record<string, ContractAnyType>
-  ? {
-      [K in keyof THeaders]: THeaders[K] extends ContractAnyType
-        ? LowercaseKeys<SchemaInputOrType<THeaders[K]>>
-        : never;
-    }
+  ? LowercaseKeys<
+      UnknownOrUndefinedObjectValuesToOptionalKeys<{
+        [K in keyof THeaders]: THeaders[K] extends ContractAnyType
+          ? SchemaInputOrType<THeaders[K]>
+          : never;
+      }>
+    >
   : // else
     undefined;
+
+/**
+ * { foo: string | undefined } => { foo?: string | undefined }
+ * { foo: unknown } => { foo?: unknown }
+ *
+ * @internal
+ */
+export type UnknownOrUndefinedObjectValuesToOptionalKeys<T> = {
+  [K in keyof T as undefined extends T[K]
+    ? K
+    : unknown extends T[K]
+    ? K
+    : never]?: T[K];
+} & {
+  [K in keyof T as undefined extends T[K]
+    ? never
+    : unknown extends T[K]
+    ? never
+    : K]: T[K];
+};
 
 /**
  * For a given app route, infer the headers output type

--- a/libs/ts-rest/core/src/lib/infer-types.spec.ts
+++ b/libs/ts-rest/core/src/lib/infer-types.spec.ts
@@ -848,7 +848,7 @@ describe('ClientInferRequest', () => {
     });
 
     const client = initClient(contract, { baseUrl: '' });
-    client.getPost({ headers: { 'x-foo': 'string' } });
+    const testUsage = () => client.getPost({ headers: { 'x-foo': 'string' } });
 
     type Actual = ClientInferRequest<typeof contract.getPost>['headers'];
     type TestResult = Expect<
@@ -876,7 +876,7 @@ describe('ClientInferRequest', () => {
     });
 
     const client = initClient(contract, { baseUrl: '' });
-    client.getPost({ headers: { 'x-foo': 1 } });
+    const testUsage = () => client.getPost({ headers: { 'x-foo': 1 } });
 
     type Actual = ClientInferRequest<typeof contract.getPost>['headers'];
     type TestResult = Expect<Equal<Actual, { 'x-foo'?: number | undefined }>>;
@@ -897,7 +897,7 @@ describe('ClientInferRequest', () => {
     });
 
     const client = initClient(contract, { baseUrl: '' });
-    client.getPost({ headers: { 'x-foo': 1 } });
+    const testUsage = () => client.getPost({ headers: { 'x-foo': 1 } });
 
     type Actual = ClientInferRequest<typeof contract.getPost>['headers'];
     type TestResult = Expect<Equal<Actual, { 'x-foo'?: unknown }>>;

--- a/libs/ts-rest/core/src/lib/infer-types.spec.ts
+++ b/libs/ts-rest/core/src/lib/infer-types.spec.ts
@@ -902,6 +902,38 @@ describe('ClientInferRequest', () => {
     type Actual = ClientInferRequest<typeof contract.getPost>['headers'];
     type TestResult = Expect<Equal<Actual, { 'x-foo'?: unknown }>>;
   });
+
+  it('headers zod (4) union sometimes undefined', () => {
+    const contract = c.router({
+      getPost: {
+        method: 'GET',
+        path: '/posts',
+        headers: {
+          'x-foo': z4.union([
+            z4.string(),
+            z4.number(),
+            z4.null(),
+            z4.undefined(),
+          ]),
+          'x-required': z4.union([z4.string(), z4.number(), z4.null()]),
+        },
+        responses: {
+          200: c.noBody(),
+        },
+      },
+    });
+
+    type Actual = ClientInferRequest<typeof contract.getPost>['headers'];
+    type TestResult = Expect<
+      Equal<
+        Actual,
+        {
+          'x-foo'?: string | number | null | undefined; // <- this one becomes optional as it contains undefined
+          'x-required': string | number | null;
+        }
+      >
+    >;
+  });
 });
 
 describe('UnknownOrUndefinedObjectValuesToOptionalKeys', () => {

--- a/libs/ts-rest/core/src/lib/standard-schema-utils.ts
+++ b/libs/ts-rest/core/src/lib/standard-schema-utils.ts
@@ -158,7 +158,6 @@ export const validateMultiSchemaObject = (
 
   for (const [key, schema] of subSchemas.entries()) {
     const value = headersMap.get(key);
-    console.log(`validating against schema key:${key} value:${value}`);
     const result = validateAgainstStandardSchema(value, schema);
 
     if (result.error) {
@@ -172,8 +171,6 @@ export const validateMultiSchemaObject = (
       headersMap.set(key, result.value);
     }
   }
-
-  console.log('issues', issues);
 
   if (issues.length > 0) {
     return {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "vitest": "0.32.4",
     "vue": "^3.3.4",
     "zod": "3.22.3",
+    "zod4": "npm:zod@3.25.47",
     "zustand": "^4.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
       zod:
         specifier: 3.22.3
         version: 3.22.3
+      zod4:
+        specifier: npm:zod@3.25.47
+        version: zod@3.25.47
       zustand:
         specifier: ^4.1.1
         version: 4.1.1(immer@9.0.15)(react@18.3.1)
@@ -10999,6 +11002,9 @@ packages:
 
   zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
+
+  zod@3.25.47:
+    resolution: {integrity: sha512-+f8+agSYoT9niC0VUL60IuXnr81FJeJ27Lf5YPrmcxTWmygcpGBeEuAAovDDEjkyQ36KyqNswwbhISZ1Z7yY+A==}
 
   zustand@4.1.1:
     resolution: {integrity: sha512-h4F3WMqsZgvvaE0n3lThx4MM81Ls9xebjvrABNzf5+jb3/03YjNTSgZXeyrvXDArMeV9untvWXRw1tY+ntPYbA==}
@@ -24288,6 +24294,8 @@ snapshots:
       commander: 9.4.1
 
   zod@3.22.3: {}
+
+  zod@3.25.47: {}
 
   zustand@4.1.1(immer@9.0.15)(react@18.3.1):
     dependencies:

--- a/test-projects/valibot/index.ts
+++ b/test-projects/valibot/index.ts
@@ -1,7 +1,7 @@
 import { createExpressEndpoints, initServer } from '@ts-rest/express';
 import express from 'express';
 import * as bodyParser from 'body-parser';
-import { initContract } from '@ts-rest/core';
+import { initClient, initContract } from '@ts-rest/core';
 import * as v from 'valibot';
 
 const c = initContract();
@@ -24,6 +24,12 @@ const contract = c.router({
     pathParams: v.object({
       id: StringToNumberSchema,
     }),
+    headers: {
+      'x-test': v.pipe(
+        v.unknown(),
+        v.transform((i) => Number(i)),
+      ),
+    },
     responses: {
       200: PokemonSchema,
     },
@@ -53,6 +59,9 @@ const contract = c.router({
     },
   },
 });
+
+const client = initClient(contract, { baseUrl: 'http://localhost:8000' });
+const testHeaders = () => client.getPokemon({ params: { id: '1' } });
 
 export const app = express();
 app.use(bodyParser.urlencoded({ extended: false }));

--- a/test-projects/zod-3/index.ts
+++ b/test-projects/zod-3/index.ts
@@ -1,7 +1,7 @@
 import { createExpressEndpoints, initServer } from '@ts-rest/express';
 import express from 'express';
 import * as bodyParser from 'body-parser';
-import { initContract } from '@ts-rest/core';
+import { initClient, initContract } from '@ts-rest/core';
 import { generateOpenApi } from '@ts-rest/open-api';
 import { z } from 'zod';
 
@@ -16,6 +16,9 @@ const contract = c.router({
   getPokemon: {
     method: 'GET',
     path: '/pokemon/:id',
+    headers: z.object({
+      'x-test': z.coerce.number().optional(),
+    }),
     pathParams: z.object({
       id: z.coerce.number(),
     }),
@@ -48,6 +51,9 @@ const contract = c.router({
     },
   },
 });
+
+const client = initClient(contract, { baseUrl: 'http://localhost:8000' });
+const testHeaders = () => client.getPokemon({ params: { id: 1 } });
 
 export const openApiSchema = generateOpenApi(contract, {
   info: {

--- a/test-projects/zod-4/index.ts
+++ b/test-projects/zod-4/index.ts
@@ -1,7 +1,7 @@
 import { createExpressEndpoints, initServer } from '@ts-rest/express';
 import express from 'express';
 import * as bodyParser from 'body-parser';
-import { initContract, isZodType } from '@ts-rest/core';
+import { initClient, initContract, isZodType } from '@ts-rest/core';
 import { z } from 'zod/v4';
 
 const c = initContract();
@@ -15,6 +15,9 @@ export const contract = c.router({
   getPokemon: {
     method: 'GET',
     path: '/pokemon/:id',
+    headers: {
+      optional: z.coerce.number().optional(),
+    },
     pathParams: z.object({
       id: z.coerce.number(),
     }),
@@ -47,6 +50,10 @@ export const contract = c.router({
     },
   },
 });
+
+const client = initClient(contract, { baseUrl: '' });
+
+client.getPokemon({ headers: {} });
 
 export const app = express();
 app.use(bodyParser.urlencoded({ extended: false }));

--- a/test-projects/zod-4/index.ts
+++ b/test-projects/zod-4/index.ts
@@ -53,7 +53,7 @@ export const contract = c.router({
 
 const client = initClient(contract, { baseUrl: '' });
 
-client.getPokemon({ headers: {} });
+client.getPokemon({ params: { id: '1' } });
 
 export const app = express();
 app.use(bodyParser.urlencoded({ extended: false }));

--- a/test-projects/zod-4/index.ts
+++ b/test-projects/zod-4/index.ts
@@ -52,8 +52,7 @@ export const contract = c.router({
 });
 
 const client = initClient(contract, { baseUrl: 'http://localhost:8000' });
-
-client.getPokemon({ params: { id: '1' } });
+const testHeaders = () => client.getPokemon({ params: { id: '1' } });
 
 export const app = express();
 app.use(bodyParser.urlencoded({ extended: false }));

--- a/test-projects/zod-4/index.ts
+++ b/test-projects/zod-4/index.ts
@@ -51,7 +51,7 @@ export const contract = c.router({
   },
 });
 
-const client = initClient(contract, { baseUrl: '' });
+const client = initClient(contract, { baseUrl: 'http://localhost:8000' });
 
 client.getPokemon({ params: { id: '1' } });
 


### PR DESCRIPTION
Zod4 now uses `unknown` as the type for the input to `z.coerce.X`

Updated our generic handling for inferring client side header input such that this works perfectly now.

This should be a generic solution for any validator which allows an 'unknown' input, the original implementation was an oversight on my behalf.

⬇️ The key thing that now works
<img width="551" alt="Screenshot 2025-06-02 at 10 33 34" src="https://github.com/user-attachments/assets/76674220-4794-4548-a6f8-7a1ce70caf17" />

Also, added Zod4 to the main repo as it's own aliased package, not sure why I didn't do this until now!