### PR TITLE
Fix Quickstart link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ts-rest offers a simple way to define a contract for your API, which can be both
 - Full optional OpenAPI integration 📝
 
 <div align="center">
-  <h3>👉 Start reading the official <a href="https://ts-rest.com/docs/quickstart?utm_source=github&utm_medium=documentation&utm_campaign=readme">Quickstart Guide</a> 👈</h3>
+  <h3>👉 Start reading the official <a href="https://ts-rest.com/quickstart?utm_source=github&utm_medium=documentation&utm_campaign=readme">Quickstart Guide</a> 👈</h3>
 </div>
 
 ### Super Simple Example
@@ -96,7 +96,7 @@ const result = await client.getPosts({
 Create a contract, implement it on your server then consume it in your client. Incrementally adopt, trial it with your team, then get shipping faster.
 
 <div align="center">
-  <h3>👉 Start reading the official <a href="https://ts-rest.com/docs/quickstart?utm_source=github&utm_medium=documentation&utm_campaign=readme">Quickstart Guide</a> 👈</h3>
+  <h3>👉 Start reading the official <a href="https://ts-rest.com/quickstart?utm_source=github&utm_medium=documentation&utm_campaign=readme">Quickstart Guide</a> 👈</h3>
 </div>
 
 ## Contributors ✨


### PR DESCRIPTION
The current link in the README for the Quickstart section on the website incorrectly has `/docs` in the path, as the actual URL for it no longer includes it, resulting in a 404 page.