### PR TITLE
fix: formdata being sent would not automatically set the header as Content-Type: multipart/form-data.

### DIFF
--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -286,11 +286,18 @@ export const fetchApi = (options: FetchApiOptions) => {
 
   if (route.method !== 'GET') {
     if ('contentType' in route && route.contentType === 'multipart/form-data') {
+      const isFormData = body instanceof FormData;
       fetcherArgs = {
         ...fetcherArgs,
         contentType: 'multipart/form-data',
-        body: body instanceof FormData ? body : createFormData(body),
+        body: isFormData ? body : createFormData(body),
       };
+      if (isFormData && fetcherArgs.headers) {
+        const headers = { ...fetcherArgs.headers };
+        delete headers['Content-Type'];
+        delete headers['content-type'];
+        fetcherArgs.headers = headers;
+      }
     } else if (
       'contentType' in route &&
       route.contentType === 'application/x-www-form-urlencoded'


### PR DESCRIPTION
I was previously working on a project and used ts-rest on it, and would send formdata through it but it would return an error stating that I haven't set the right header, which is:

"Object { status: 400, body: "Failed to parse form: request Content-Type isn't multipart/form-data\n", headers: Headers(2) }"

This happens when I don't set the header myself, and in the documentation it states that formdata **SHOULD** set the header automatically. My temporary project solution is:

  createPost: {
    method: "POST",
    path: "/api/post/create",
    body: c.type<FormData>(),
    contentType: "multipart/form-data",
    responses: {
      200: c.type<Post>(),
    },
  },
  
Which had the content type set directly within the contract, far from ideal and it should work normally. I made the fix and lightly tested it within nest.