### PR TITLE
use ClientInferRequest-inferred args for evaluateFetchApiArgs and getRouteQuery

### DIFF
--- a/libs/ts-rest/core/src/lib/client.ts
+++ b/libs/ts-rest/core/src/lib/client.ts
@@ -331,7 +331,7 @@ export const fetchApi = (options: FetchApiOptions) => {
 export const evaluateFetchApiArgs = <TAppRoute extends AppRoute>(
   route: TAppRoute,
   clientArgs: InitClientArgs,
-  inputArgs?: ClientInferRequest<AppRouteMutation, ClientArgs>,
+  inputArgs?: ClientInferRequest<TAppRoute, ClientArgs>,
 ) => {
   const {
     query,
@@ -429,9 +429,7 @@ export const getRouteQuery = <TAppRoute extends AppRoute>(
   clientArgs: InitClientArgs,
 ) => {
   const knownResponseStatuses = Object.keys(route.responses);
-  return async (
-    inputArgs?: ClientInferRequest<AppRouteMutation, ClientArgs>,
-  ) => {
+  return async (inputArgs?: ClientInferRequest<TAppRoute, ClientArgs>) => {
     const fetchApiArgs = evaluateFetchApiArgs(route, clientArgs, inputArgs);
     const response = await fetchApi(fetchApiArgs);
 


### PR DESCRIPTION
without these changes, non-bodiful-mutation operations like simple GET requests incorrectly require bodies

[playground link](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzjAnmApnAgmMAlCAVxnQBo50A3AQwBtDqSAxdGAYwAsdgsoBzAM7k+rAsXQBFQuigo4AXzgAzKBBBwA5AAEYAgLRR0AmAHo20dBoBQV8wDtjcVeLgBeRHBCsOEACYAuTQBxAFEAFQ1yMEYOQI0TSKcjSAcjQIRFRWoBOHtHAUZgASVgI2xcMRIbPPgAI2z0AFUoWjdNDhgYMAF-ExN0AA9qcFp0ADpzEGsrKjoGZlZObl5BAApnEnIkeoEmloUt+QBKGxEYSslpWXWiTY8dvdo4jq6evsHhsFGJtQ0FI9WGROQA)

---

<img width="988" height="703" alt="image" src="https://github.com/user-attachments/assets/58e66dbd-65f3-4b80-a654-1c065c1bae3e" />

---

it's possible that AppRouteMutation was originally being used just because it was the one that was most inclusive of the union'd fields, such as ones that need to be destructured in https://github.com/ts-rest/ts-rest/blob/dd7239bc950d1e254d9c9cd6df7dbccc529c33cb/libs/ts-rest/core/src/lib/client.ts#L354-L360
but this functionality doesn't need to force the function signatures to lose their genericities