### PR TITLE
fix: export TsRestRequestValidationError

### DIFF
--- a/libs/ts-rest/serverless/src/index.ts
+++ b/libs/ts-rest/serverless/src/index.ts
@@ -4,6 +4,7 @@ export * from './lib/response';
 export {
   RequestValidationError,
   ResponseValidationError,
+  TsRestRequestValidationError,
   type AppRouteImplementation,
   type AppRouteImplementationOrOptions,
   type AppRouteOptions,


### PR DESCRIPTION
As pointed out in #821, `TsRestRequestValidationError` should be exported from index.