### PR TITLE
docs(start): fixing URL for quick-start in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ts-rest offers a simple way to define a contract for your API, which can be both
 - Full optional OpenAPI integration 📝
 
 <div align="center">
-  <h3>👉 Start reading the official <a href="https://ts-rest.com/docs/quickstart?utm_source=github&utm_medium=documentation&utm_campaign=readme">Quickstart Guide</a> 👈</h3>
+  <h3>👉 Start reading the official <a href="https://ts-rest.com/quickstart?utm_source=github&utm_medium=documentation&utm_campaign=readme">Quickstart Guide</a> 👈</h3>
 </div>
 
 ### Super Simple Example


### PR DESCRIPTION
### Summary
There's a small typo in the URL for the quick-start, which redirects to a Not Found page in Vercel. This PR adjust is to redirect to the https://ts-rest.com/quickstart 😅 

##### Screenshots
<img width="1510" height="920" alt="Screenshot 2026-02-18 at 22 35 55" src="https://github.com/user-attachments/assets/56b18427-7b06-427b-afb6-7d4d47117493" />
