### PR TITLE
test(open-api): preserve optional security alternatives

### DIFF
--- a/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
+++ b/libs/ts-rest/open-api/src/lib/ts-rest-open-api.spec.ts
@@ -906,6 +906,42 @@ describe('ts-rest-open-api', () => {
       );
     });
 
+    it('preserves optional security alternatives from operationMapper', async () => {
+      const optionalSecurity: SecurityRequirementObject[] = [
+        {},
+        {
+          BasicAuth: [],
+        },
+      ];
+
+      const apiDoc = generateOpenApi(
+        router,
+        {
+          info: { title: 'Blog API', version: '0.1' },
+          components: {
+            securitySchemes: {
+              BasicAuth: {
+                type: 'http',
+                scheme: 'basic',
+              },
+            },
+          },
+        },
+        {
+          operationMapper: (operation, appRoute) => ({
+            ...operation,
+            ...(appRoute.path === '/health'
+              ? {
+                  security: optionalSecurity,
+                }
+              : {}),
+          }),
+        },
+      );
+
+      expect(apiDoc.paths['/health'].get.security).toEqual(optionalSecurity);
+    });
+
     it('works with zod refine', () => {
       const routerWithRefine = c.router({
         endpointWithZodRefine: {


### PR DESCRIPTION
## Summary

- Add an OpenAPI generator regression for optional security alternatives returned by `operationMapper`.
- Verify an empty security requirement is preserved alongside BasicAuth.

## Validation

- Git diff whitespace check passed.
- Targeted nx test could not start because this temporary checkout has no node_modules.
