### PR TITLE
fix(core): preserve object-based header inference

### DIFF
--- a/.changeset/fix-infer-headers-output.md
+++ b/.changeset/fix-infer-headers-output.md
@@ -1,0 +1,5 @@
+---
+'@ts-rest/core': patch
+---
+
+Fix server-side inference for object-based request headers so header names are lowercased while schema output value types are preserved.

--- a/libs/ts-rest/core/src/lib/dsl.ts
+++ b/libs/ts-rest/core/src/lib/dsl.ts
@@ -232,9 +232,6 @@ export type InferHeadersInput<
   : // if empty object
   IsEmptyObject<THeaders> extends true
   ? {}
-  : // if Zod
-  THeaders extends z.AnyZodObject
-  ? LowercaseKeys<z.input<THeaders>>
   : // if modern object-based headers
   THeaders extends Record<string, ContractAnyType>
   ? LowercaseKeys<
@@ -244,6 +241,9 @@ export type InferHeadersInput<
           : never;
       }>
     >
+  : // if legacy Zod object
+  THeaders extends z.AnyZodObject
+  ? LowercaseKeys<z.input<THeaders>>
   : // else
     undefined;
 
@@ -278,16 +278,16 @@ export type InferHeadersOutput<
   : // if empty object
   IsEmptyObject<THeaders> extends true
   ? {}
-  : // if Zod
-  THeaders extends z.AnyZodObject
-  ? LowercaseKeys<z.output<THeaders>>
   : // if modern object-based headers
   THeaders extends Record<string, ContractAnyType>
-  ? {
+  ? LowercaseKeys<{
       [K in keyof THeaders]: THeaders[K] extends ContractAnyType
-        ? LowercaseKeys<SchemaOutputOrType<THeaders[K]>>
+        ? SchemaOutputOrType<THeaders[K]>
         : never;
-    }
+    }>
+  : // if legacy Zod object
+  THeaders extends z.AnyZodObject
+  ? LowercaseKeys<z.output<THeaders>>
   : '3';
 
 type ApplyOptions<

--- a/libs/ts-rest/core/src/lib/infer-headers-output.spec.ts
+++ b/libs/ts-rest/core/src/lib/infer-headers-output.spec.ts
@@ -1,0 +1,58 @@
+import { initContract } from './dsl';
+import type { InferHeadersInput, InferHeadersOutput } from './dsl';
+import type { ServerInferRequest } from './infer-types';
+
+describe('object-based header inference', () => {
+  const c = initContract();
+
+  const contract = c.router({
+    example: {
+      method: 'GET',
+      path: '/example',
+      headers: {
+        'X-Request-Id': c.type<string>(),
+        'If-Match': c.type<number>(),
+      },
+      responses: {
+        200: c.type<null>(),
+      },
+    },
+  });
+
+  type Route = typeof contract.example;
+
+  it('preserves output types and lowercases header names', () => {
+    type Headers = InferHeadersOutput<Route>;
+    type Request = ServerInferRequest<Route>;
+
+    const assertOutput = (headers: Headers) => {
+      const requestId: string = headers['x-request-id'];
+      const ifMatch: number = headers['if-match'];
+
+      return { ifMatch, requestId };
+    };
+
+    const assertRequest = (headers: Request['headers']) => {
+      const requestId: string = headers['x-request-id'];
+      const ifMatch: number = headers['if-match'];
+
+      return { ifMatch, requestId };
+    };
+
+    expect(typeof assertOutput).toBe('function');
+    expect(typeof assertRequest).toBe('function');
+  });
+
+  it('preserves input types and lowercases header names', () => {
+    type Headers = InferHeadersInput<Route>;
+
+    const assertInput = (headers: Headers) => {
+      const requestId: string = headers['x-request-id'];
+      const ifMatch: number = headers['if-match'];
+
+      return { ifMatch, requestId };
+    };
+
+    expect(typeof assertInput).toBe('function');
+  });
+});


### PR DESCRIPTION
Fixes #872

## Summary

Fix object-based request-header inference.

There are two related issues:

1. `InferHeadersOutput` applies `LowercaseKeys` to each individual header schema output instead of the complete headers object.
2. The legacy Zod-object branch is checked before the modern object-based headers branch in both `InferHeadersInput` and `InferHeadersOutput`.

The second issue matters for Zod 4 consumers because the legacy `z.AnyZodObject` type is not part of the Zod 4 API. A declaration error can be hidden by `skipLibCheck`, while conditional inference still resolves through the wrong branch.

This change:

- gives modern object-based headers precedence over the legacy Zod-object branch;
- lowercases keys of the complete mapped output object;
- preserves each header schema's input and output type;
- adds regression coverage for input, output, and `ServerInferRequest`.

## Validation

- `nx test ts-rest-core --runInBand`
- `nx lint ts-rest-core`
- `nx build ts-rest-core`

Local validation passed with 210 tests passing.
